### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,7 +23,7 @@ jobs:
       run: poetry build
 
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@e777b33388fefa46ce597d8afa9c15a5357af36f
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
We should use a specific commit ID for the GitHub Action "gh-action-pypi-publish" to avoid issues like this one: https://github.com/pypa/gh-action-pypi-publish/issues/20