### PR TITLE
Codecov GitHub Action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,3 +27,28 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}
+
+  test-coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: dschep/install-poetry-action@v1.2
+
+    - name: Install dependencies
+      run: sudo apt update && sudo apt install -y --no-install-recommends python3-venv
+
+    - name: Make poetry use Python 3
+      run: sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
+
+    - name: Install poetry dependencies
+      run: poetry install
+
+    - name: Test Python with Coverage
+      run: |
+        poetry run coverage run --source=. -m unittest discover tests
+        poetry run coverage xml
+
+    - uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,7 +50,10 @@ jobs:
       run: poetry install
 
     - name: Test Python with Coverage
-      run: poetry run coverage run --source=. -m unittest discover tests
+      run: |
+        poetry run coverage run --source=. -m unittest discover tests
+        poetry run coverage xml
 
-    - name: Upload coverage results to Codecov.io
-      run: bash <(curl -s https://codecov.io/bash) -cF python
+    - uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
[Codecov](https://codecov.io/) was not working as expected, the reason is because:

"The upload token is required for all uploads, except originating from public project using Travis-CI, Circle CI, or AppVeyor CI." [Codecov FAQ](https://docs.codecov.io/docs/frequently-asked-questions)

I also discover that they have their own GitHub Action for this so I did the changes to start using it:
https://github.com/marketplace/actions/codecov
