### PR TITLE
Support "arch" in snap search

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,26 +1,24 @@
 [tool.poetry]
-name = "canonicalwebteam.store-api"
-version = "1.0.4"
-description = ""
-authors = ["Canonical Web Team <webteam@canonical.com>"]
-license = "LGPL-3.0"
-readme = "README.md"
+name = 'canonicalwebteam.store-api'
+version = '1.0.5'
+description = ''
+authors = ['Canonical Web Team <webteam@canonical.com>']
+license = 'LGPL-3.0'
+readme = 'README.md'
 
-packages = [
-    { include = "canonicalwebteam" }
-]
+[[tool.poetry.packages]]
+include = 'canonicalwebteam'
 
 [tool.poetry.dependencies]
-python = "^3.6"
-requests = "^2.22"
-vcrpy-unittest = "^0.1.7"
-coverage = "^5.0"
-semver = "^2.9"
+python = '^3.6'
+requests = '^2.22'
+vcrpy-unittest = '^0.1.7'
+coverage = '^5.0'
+semver = '^2.9'
 
 [tool.poetry.dev-dependencies]
-pytest = "^5.3"
+pytest = '^5.3'
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
-
+requires = ['poetry>=0.12']
+build-backend = 'poetry.masonry.api'

--- a/tests/cassettes/SnapcraftApiTest.test_search_by_arch.yaml
+++ b/tests/cassettes/SnapcraftApiTest.test_search_by_arch.yaml
@@ -1,0 +1,319 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+      X-Ubuntu-Architecture:
+      - wide
+      X-Ubuntu-Series:
+      - '16'
+    method: GET
+    uri: https://api.snapcraft.io/api/v1/snaps/search?q=toto&size=10&page=1&scope=wide&confinement=strict%2Cclassic&fields=package_name%2Ctitle%2Csummary%2Cicon_url%2Cmedia%2Cpublisher%2Cdeveloper_validation%2Corigin%2Capps%2Csections&arch=wide
+  response:
+    body:
+      string: '{"_embedded": {"clickindex:package": [{"apps": ["toto"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/Artboard_0gjcICX.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/Artboard_0gjcICX.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/Artboard_fNArkm1.png"}],
+        "origin": "tbmb", "package_name": "toto", "publisher": "Thomas Bille", "sections":
+        [{"featured": false, "name": "social"}], "summary": "Cool tool for happy people",
+        "title": "toto"}, {"apps": [], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2018/07/snpicon.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/07/snpicon.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/02.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/03.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/04.png"}],
+        "origin": "testtesttest", "package_name": "gregatronic", "publisher": "Greg
+        Hale", "sections": [], "summary": "This snap is 4x better than toto''s", "title":
+        "gregatronic"}, {"apps": ["autoskola-free6"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/ikona_K2Sqemd.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/ikona_K2Sqemd.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/Sn%C3%ADmka_obrazovky_z_2019-01-10_18-08-29.png"}],
+        "origin": "lesna.vevericka", "package_name": "autoskola-free6", "publisher":
+        "Lesn\u00e1 Veveri\u010dka", "sections": [{"featured": false, "name": "utilities"}],
+        "summary": "autoskola-free6", "title": "autoskola-free6"}, {"apps": ["otot"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/icon_copy_1.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/icon_copy_1.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/red_copy_1.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/blue_copy_1.png"}],
+        "origin": "tbmb", "package_name": "otot", "publisher": "Thomas Bille", "sections":
+        [], "summary": "!!!esrevinu pans eht fo pans tnatropmi tsom ehT!", "title":
+        "otot"}, {"apps": [], "developer_validation": "unproven", "icon_url": "",
+        "media": [], "origin": "jkfran", "package_name": "toto-fran", "publisher":
+        "Francisco Jim\u00e9nez Cabrera", "sections": [], "summary": "The most important
+        snap of the snap universe", "title": "toto-fran"}, {"apps": ["beautiful-dog"],
+        "developer_validation": "unproven", "icon_url": "", "media": [], "origin":
+        "totoqa", "package_name": "beautiful-dog", "publisher": "Toto qa", "sections":
+        [], "summary": "GNU Hello, the \"beautiful-dog world\" snap", "title": "beautiful-dog"},
+        {"apps": ["test-toto"], "developer_validation": "unproven", "icon_url": "",
+        "media": [], "origin": "totoqa", "package_name": "test-toto", "publisher":
+        "Toto qa", "sections": [], "summary": "GNU Hello, the \"test-toto world\"
+        snap", "title": "test-toto"}]}, "_links": {"self": {"href": "https://api.snapcraft.io/api/v1/snaps/search?q=toto&size=10&page=1&scope=wide&confinement=strict%2Cclassic&fields=package_name%2Ctitle%2Csummary%2Cicon_url%2Cmedia%2Cpublisher%2Cdeveloper_validation%2Corigin%2Capps%2Csections&arch=wide"}},
+        "total": 7}'
+    headers:
+      Content-Length:
+      - '3682'
+      Content-Type:
+      - application/hal+json
+      Date:
+      - Wed, 19 Feb 2020 13:02:19 GMT
+      Server:
+      - gunicorn/19.7.1
+      Snap-Store-Version:
+      - '18'
+      Vary:
+      - X-Ubuntu-Store, X-Ubuntu-Series, X-Ubuntu-Architecture
+      Via:
+      - 1.1 juju-7794b8-prod-ols-snap-store-indep-1375 (squid/3.5.27)
+      X-Cache:
+      - MISS from juju-7794b8-prod-ols-snap-store-indep-1375
+      X-Cache-Lookup:
+      - MISS from juju-7794b8-prod-ols-snap-store-indep-1375:3128
+      X-Request-Id:
+      - 59C57682D4660A325CA101BB5E4D31DA36132BA
+      X-VCS-Revision:
+      - 3476d7a
+      X-View-Name:
+      - snapdevicegw.webapi_search.snap_search
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+      X-Ubuntu-Architecture:
+      - amd64
+      X-Ubuntu-Series:
+      - '16'
+    method: GET
+    uri: https://api.snapcraft.io/api/v1/snaps/search?q=toto&size=10&page=1&scope=wide&confinement=strict%2Cclassic&fields=package_name%2Ctitle%2Csummary%2Cicon_url%2Cmedia%2Cpublisher%2Cdeveloper_validation%2Corigin%2Capps%2Csections&arch=amd64
+  response:
+    body:
+      string: '{"_embedded": {"clickindex:package": [{"apps": ["toto"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/Artboard_0gjcICX.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/Artboard_0gjcICX.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/Artboard_fNArkm1.png"}],
+        "origin": "tbmb", "package_name": "toto", "publisher": "Thomas Bille", "sections":
+        [{"featured": false, "name": "social"}], "summary": "Cool tool for happy people",
+        "title": "toto"}, {"apps": [], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2018/07/snpicon.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/07/snpicon.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/02.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/03.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/04.png"}],
+        "origin": "testtesttest", "package_name": "gregatronic", "publisher": "Greg
+        Hale", "sections": [], "summary": "This snap is 4x better than toto''s", "title":
+        "gregatronic"}, {"apps": ["autoskola-free6"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/ikona_K2Sqemd.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/ikona_K2Sqemd.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/Sn%C3%ADmka_obrazovky_z_2019-01-10_18-08-29.png"}],
+        "origin": "lesna.vevericka", "package_name": "autoskola-free6", "publisher":
+        "Lesn\u00e1 Veveri\u010dka", "sections": [{"featured": false, "name": "utilities"}],
+        "summary": "autoskola-free6", "title": "autoskola-free6"}, {"apps": ["otot"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/icon_copy_1.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/icon_copy_1.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/red_copy_1.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/blue_copy_1.png"}],
+        "origin": "tbmb", "package_name": "otot", "publisher": "Thomas Bille", "sections":
+        [], "summary": "!!!esrevinu pans eht fo pans tnatropmi tsom ehT!", "title":
+        "otot"}, {"apps": [], "developer_validation": "unproven", "icon_url": "",
+        "media": [], "origin": "jkfran", "package_name": "toto-fran", "publisher":
+        "Francisco Jim\u00e9nez Cabrera", "sections": [], "summary": "The most important
+        snap of the snap universe", "title": "toto-fran"}, {"apps": ["beautiful-dog"],
+        "developer_validation": "unproven", "icon_url": "", "media": [], "origin":
+        "totoqa", "package_name": "beautiful-dog", "publisher": "Toto qa", "sections":
+        [], "summary": "GNU Hello, the \"beautiful-dog world\" snap", "title": "beautiful-dog"}]},
+        "_links": {"self": {"href": "https://api.snapcraft.io/api/v1/snaps/search?q=toto&size=10&page=1&scope=wide&confinement=strict%2Cclassic&fields=package_name%2Ctitle%2Csummary%2Cicon_url%2Cmedia%2Cpublisher%2Cdeveloper_validation%2Corigin%2Capps%2Csections&arch=amd64"}},
+        "total": 6}'
+    headers:
+      Content-Length:
+      - '3428'
+      Content-Type:
+      - application/hal+json
+      Date:
+      - Wed, 19 Feb 2020 13:02:19 GMT
+      Server:
+      - gunicorn/19.7.1
+      Snap-Store-Version:
+      - '18'
+      Vary:
+      - X-Ubuntu-Store, X-Ubuntu-Series, X-Ubuntu-Architecture
+      Via:
+      - 1.1 juju-7794b8-prod-ols-snap-store-indep-1375 (squid/3.5.27)
+      X-Cache:
+      - MISS from juju-7794b8-prod-ols-snap-store-indep-1375
+      X-Cache-Lookup:
+      - MISS from juju-7794b8-prod-ols-snap-store-indep-1375:3128
+      X-Request-Id:
+      - 59C57682D4660A325CA101BB5E4D31DB3613619
+      X-VCS-Revision:
+      - 3476d7a
+      X-View-Name:
+      - snapdevicegw.webapi_search.snap_search
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+      X-Ubuntu-Architecture:
+      - wide
+      X-Ubuntu-Series:
+      - '16'
+    method: GET
+    uri: https://api.snapcraft.io/api/v1/snaps/search?q=toto&size=10&page=1&scope=wide&confinement=strict%2Cclassic&fields=package_name%2Ctitle%2Csummary%2Cicon_url%2Cmedia%2Cpublisher%2Cdeveloper_validation%2Corigin%2Capps%2Csections&arch=wide
+  response:
+    body:
+      string: '{"_embedded": {"clickindex:package": [{"apps": ["toto"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/Artboard_0gjcICX.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/Artboard_0gjcICX.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/Artboard_fNArkm1.png"}],
+        "origin": "tbmb", "package_name": "toto", "publisher": "Thomas Bille", "sections":
+        [{"featured": false, "name": "social"}], "summary": "Cool tool for happy people",
+        "title": "toto"}, {"apps": [], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2018/07/snpicon.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/07/snpicon.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/02.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/03.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/04.png"}],
+        "origin": "testtesttest", "package_name": "gregatronic", "publisher": "Greg
+        Hale", "sections": [], "summary": "This snap is 4x better than toto''s", "title":
+        "gregatronic"}, {"apps": ["autoskola-free6"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/ikona_K2Sqemd.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/ikona_K2Sqemd.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/Sn%C3%ADmka_obrazovky_z_2019-01-10_18-08-29.png"}],
+        "origin": "lesna.vevericka", "package_name": "autoskola-free6", "publisher":
+        "Lesn\u00e1 Veveri\u010dka", "sections": [{"featured": false, "name": "utilities"}],
+        "summary": "autoskola-free6", "title": "autoskola-free6"}, {"apps": ["otot"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/icon_copy_1.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/icon_copy_1.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/red_copy_1.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/blue_copy_1.png"}],
+        "origin": "tbmb", "package_name": "otot", "publisher": "Thomas Bille", "sections":
+        [], "summary": "!!!esrevinu pans eht fo pans tnatropmi tsom ehT!", "title":
+        "otot"}, {"apps": [], "developer_validation": "unproven", "icon_url": "",
+        "media": [], "origin": "jkfran", "package_name": "toto-fran", "publisher":
+        "Francisco Jim\u00e9nez Cabrera", "sections": [], "summary": "The most important
+        snap of the snap universe", "title": "toto-fran"}, {"apps": ["beautiful-dog"],
+        "developer_validation": "unproven", "icon_url": "", "media": [], "origin":
+        "totoqa", "package_name": "beautiful-dog", "publisher": "Toto qa", "sections":
+        [], "summary": "GNU Hello, the \"beautiful-dog world\" snap", "title": "beautiful-dog"},
+        {"apps": ["test-toto"], "developer_validation": "unproven", "icon_url": "",
+        "media": [], "origin": "totoqa", "package_name": "test-toto", "publisher":
+        "Toto qa", "sections": [], "summary": "GNU Hello, the \"test-toto world\"
+        snap", "title": "test-toto"}]}, "_links": {"self": {"href": "https://api.snapcraft.io/api/v1/snaps/search?q=toto&size=10&page=1&scope=wide&confinement=strict%2Cclassic&fields=package_name%2Ctitle%2Csummary%2Cicon_url%2Cmedia%2Cpublisher%2Cdeveloper_validation%2Corigin%2Capps%2Csections&arch=wide"}},
+        "total": 7}'
+    headers:
+      Content-Length:
+      - '3682'
+      Content-Type:
+      - application/hal+json
+      Date:
+      - Wed, 19 Feb 2020 13:02:20 GMT
+      Server:
+      - gunicorn/19.7.1
+      Snap-Store-Version:
+      - '18'
+      Vary:
+      - X-Ubuntu-Store, X-Ubuntu-Series, X-Ubuntu-Architecture
+      Via:
+      - 1.1 juju-7794b8-prod-ols-snap-store-indep-1374 (squid/3.5.27)
+      X-Cache:
+      - MISS from juju-7794b8-prod-ols-snap-store-indep-1374
+      X-Cache-Lookup:
+      - MISS from juju-7794b8-prod-ols-snap-store-indep-1374:3128
+      X-Request-Id:
+      - 59C57682D4660A325CA101BB5E4D31DB36139C6
+      X-VCS-Revision:
+      - 3476d7a
+      X-View-Name:
+      - snapdevicegw.webapi_search.snap_search
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+      X-Ubuntu-Architecture:
+      - i386
+      X-Ubuntu-Series:
+      - '16'
+    method: GET
+    uri: https://api.snapcraft.io/api/v1/snaps/search?q=toto&size=10&page=1&scope=wide&confinement=strict%2Cclassic&fields=package_name%2Ctitle%2Csummary%2Cicon_url%2Cmedia%2Cpublisher%2Cdeveloper_validation%2Corigin%2Capps%2Csections&arch=i386
+  response:
+    body:
+      string: '{"_embedded": {"clickindex:package": [{"apps": [], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/Artboard_0gjcICX.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/Artboard_0gjcICX.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/Artboard_fNArkm1.png"}],
+        "origin": "tbmb", "package_name": "toto", "publisher": "Thomas Bille", "sections":
+        [{"featured": false, "name": "social"}], "summary": "Cool tool for happy people",
+        "title": "toto"}, {"apps": [], "developer_validation": "unproven", "icon_url":
+        "", "media": [], "origin": "jkfran", "package_name": "toto-fran", "publisher":
+        "Francisco Jim\u00e9nez Cabrera", "sections": [], "summary": "The most important
+        snap of the snap universe", "title": "toto-fran"}, {"apps": ["test-toto"],
+        "developer_validation": "unproven", "icon_url": "", "media": [], "origin":
+        "totoqa", "package_name": "test-toto", "publisher": "Toto qa", "sections":
+        [], "summary": "GNU Hello, the \"test-toto world\" snap", "title": "test-toto"}]},
+        "_links": {"self": {"href": "https://api.snapcraft.io/api/v1/snaps/search?q=toto&size=10&page=1&scope=wide&confinement=strict%2Cclassic&fields=package_name%2Ctitle%2Csummary%2Cicon_url%2Cmedia%2Cpublisher%2Cdeveloper_validation%2Corigin%2Capps%2Csections&arch=i386"}},
+        "total": 3}'
+    headers:
+      Content-Length:
+      - '1407'
+      Content-Type:
+      - application/hal+json
+      Date:
+      - Wed, 19 Feb 2020 13:02:21 GMT
+      Server:
+      - gunicorn/19.7.1
+      Snap-Store-Version:
+      - '18'
+      Vary:
+      - X-Ubuntu-Store, X-Ubuntu-Series, X-Ubuntu-Architecture
+      Via:
+      - 1.1 juju-7794b8-prod-ols-snap-store-indep-1375 (squid/3.5.27)
+      X-Cache:
+      - MISS from juju-7794b8-prod-ols-snap-store-indep-1375
+      X-Cache-Lookup:
+      - MISS from juju-7794b8-prod-ols-snap-store-indep-1375:3128
+      X-Request-Id:
+      - 59C57682D4660A325CA101BB5E4D31DC3613E2B
+      X-VCS-Revision:
+      - 3476d7a
+      X-View-Name:
+      - snapdevicegw.webapi_search.snap_search
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/SnapcraftApiTest.test_search_size.yaml
+++ b/tests/cassettes/SnapcraftApiTest.test_search_size.yaml
@@ -1,0 +1,3330 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+      X-Ubuntu-Architecture:
+      - wide
+      X-Ubuntu-Series:
+      - '16'
+    method: GET
+    uri: https://api.snapcraft.io/api/v1/snaps/search?q=code&size=100&page=1&scope=wide&confinement=strict%2Cclassic&fields=package_name%2Ctitle%2Csummary%2Cicon_url%2Cmedia%2Cpublisher%2Cdeveloper_validation%2Corigin%2Capps%2Csections&arch=wide
+  response:
+    body:
+      string: '{"_embedded": {"clickindex:package": [{"apps": ["code", "url-handler"],
+        "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/code_ozwVHSV.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/code_ozwVHSV.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/09/home-screenshot-linux.png"}],
+        "origin": "vscode", "package_name": "code", "publisher": "Visual Studio Code",
+        "sections": [{"featured": false, "name": "development"}], "summary": "Code
+        editing. Redefined.", "title": "Visual Studio Code"}, {"apps": ["subl"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/03/sublime-text.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/03/sublime-text.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/03/linux.png"}],
+        "origin": "snapcrafters", "package_name": "sublime-text", "publisher": "Snapcrafters",
+        "sections": [{"featured": true, "name": "development"}], "summary": "A sophisticated
+        text editor for code, markup and prose.", "title": "Sublime Text"}, {"apps":
+        ["pycharm-community"], "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/PyCharmCore256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/PyCharmCore256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/pycharm_com_general.png"}],
+        "origin": "jetbrains", "package_name": "pycharm-community", "publisher": "jetbrains",
+        "sections": [{"featured": true, "name": "development"}], "summary": "Python
+        IDE for Professional Developers", "title": "PyCharm CE"}, {"apps": ["android-studio"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/03/rsz_android_studio_icon.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/03/rsz_android_studio_icon.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/03/android-studio.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/Screenshot_20190418_002828.png"}],
+        "origin": "snapcrafters", "package_name": "android-studio", "publisher": "Snapcrafters",
+        "sections": [{"featured": true, "name": "development"}, {"featured": true,
+        "name": "featured"}], "summary": "The IDE for Android", "title": "Android
+        Studio"}, {"apps": ["riot-web"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/icon_Jfu5bEq.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/icon_Jfu5bEq.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/Screenshot_from_2019-05-29_22-37-35.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/home-communication.png"}],
+        "origin": "popey", "package_name": "riot-web", "publisher": "Alan Pope", "sections":
+        [{"featured": true, "name": "featured"}], "summary": "Communicate the way
+        you want with Riot", "title": "Riot"}, {"apps": ["npm", "desktop-launch"],
+        "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/nr-hex_1.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/nr-hex_1.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/knol.png"}],
+        "origin": "noderedteam", "package_name": "node-red", "publisher": "Node-RED-Team",
+        "sections": [{"featured": false, "name": "development"}, {"featured": true,
+        "name": "devices-and-iot"}], "summary": "Low-code programming for event-driven
+        applications", "title": "Node-RED"}, {"apps": ["docker", "machine", "compose",
+        "help"], "developer_validation": "verified", "icon_url": "", "media": [],
+        "origin": "canonical", "package_name": "docker", "publisher": "Canonical",
+        "sections": [{"featured": true, "name": "server-and-cloud"}], "summary": "Docker
+        container runtime", "title": "Docker"}, {"apps": ["mindustry"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/mindustry.png",
+        "media": [{"height": 256, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/mindustry.png",
+        "width": 256}, {"height": 1053, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/Screenshot_from_2019-09-22_19-06-24.png",
+        "width": 1920}, {"height": 1167, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/zLgp0A.png",
+        "width": 1905}, {"height": 836, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/wT1_AW.png",
+        "width": 1140}], "origin": "popey", "package_name": "mindustry", "publisher":
+        "Alan Pope", "sections": [{"featured": true, "name": "featured"}, {"featured":
+        false, "name": "games"}], "summary": "A sandbox tower defense game", "title":
+        "Mindustry"}, {"apps": ["bitwarden"], "developer_validation": "verified",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/256x256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/256x256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/04/bitwarden_ubuntu.PNG"}],
+        "origin": "bitwarden", "package_name": "bitwarden", "publisher": "8bit Solutions
+        LLC", "sections": [{"featured": false, "name": "productivity"}, {"featured":
+        true, "name": "security"}, {"featured": false, "name": "utilities"}], "summary":
+        "A secure and free password manager for all of your devices.", "title": "Bitwarden"},
+        {"apps": ["notepad-plus-plus"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/notepad-plus-plus.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/notepad-plus-plus.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/04/screenshot.png"}],
+        "origin": "mmtrt", "package_name": "notepad-plus-plus", "publisher": "Taqi
+        Raza", "sections": [{"featured": true, "name": "development"}], "summary":
+        "Notepad-Plus-Plus is a free source code editor.", "title": "Notepad-Plus-Plus
+        (WINE)"}, {"apps": ["cli", "ghb"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2016/10/handbrake-jz.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/10/handbrake-jz.png"}],
+        "origin": "jz", "package_name": "handbrake-jz", "publisher": "Jacob Zimmermann",
+        "sections": [{"featured": true, "name": "photo-and-video"}], "summary": "The
+        open source video transcoder", "title": "handbrake-jz"}, {"apps": ["gnome-calculator"],
+        "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/07/accessories-calculator.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/07/accessories-calculator.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/07/Screenshot_from_2017-07-19_15-23-11.png"}],
+        "origin": "canonical", "package_name": "gnome-calculator", "publisher": "Canonical",
+        "sections": [{"featured": true, "name": "finance"}, {"featured": false, "name":
+        "utilities"}], "summary": "GNOME Calculator", "title": "GNOME Calculator"},
+        {"apps": ["initcaddy", "restoredb", "backupdb", "mongo"], "developer_validation":
+        "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/icon-256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/icon-256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/Screen_Shot_2016-02-22_at_21.44.26.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/Screen_Shot_2016-02-22_at_21.45.00.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/Screen_Shot_2016-02-22_at_21.45.35.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/Screen_Shot_2016-02-22_at_21.47.10.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/Screen_Shot_2016-02-22_at_21.48.31.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/Screen_Shot_2016-03-09_at_20.15.01.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/Screen_Shot_2016-03-18_at_18.00.07.png"}],
+        "origin": "rocketchat", "package_name": "rocketchat-server", "publisher":
+        "Rocket.Chat", "sections": [{"featured": true, "name": "server-and-cloud"}],
+        "summary": "Group chat server for 100s,  installed in seconds.", "title":
+        "Rocket.Chat Server"}, {"apps": ["intellij-idea-community"], "developer_validation":
+        "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/icon_CE_256_2Qe5uEl.png",
+        "media": [{"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/09/screenshot_Pm7mWCg.png"},
+        {"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/icon_CE_256_2Qe5uEl.png"}],
+        "origin": "jetbrains", "package_name": "intellij-idea-community", "publisher":
+        "jetbrains", "sections": [{"featured": true, "name": "development"}], "summary":
+        "Capable & Ergonomic Java IDE", "title": "IDEA Community"}, {"apps": ["phpstorm"],
+        "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/webide.ico_HA9tBL0.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/webide.ico_HA9tBL0.png"},
+        {"height": 980, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/08/welcome.png",
+        "width": 1554}, {"height": 2105, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/08/overview.png",
+        "width": 3706}], "origin": "jetbrains", "package_name": "phpstorm", "publisher":
+        "jetbrains", "sections": [{"featured": true, "name": "development"}], "summary":
+        "PHP IDE for Professional Development", "title": "PhpStorm"}, {"apps": ["wormhole"],
+        "developer_validation": "unproven", "icon_url": "", "media": [{"type": "screenshot",
+        "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/07/Screenshot_from_2018-07-02_14-23-15.png"}],
+        "origin": "snapcrafters", "package_name": "wormhole", "publisher": "Snapcrafters",
+        "sections": [{"featured": true, "name": "utilities"}], "summary": "get things
+        from one computer to another, safely", "title": "wormhole"}, {"apps": ["copay"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/256x256_6ileytI.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/256x256_6ileytI.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/linux-image-copay1_LrjSusR.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/linux-image-copay2_2PODIzz.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/linux-image-copay3_ugITmgN.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/linux-image-copay4_A0dvFl0.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/linux-image-copay5_4zbhWlR.png"}],
+        "origin": "gabrielbitpay", "package_name": "copay", "publisher": "BitPay",
+        "sections": [{"featured": true, "name": "finance"}], "summary": "A Secure
+        Bitcoin Wallet", "title": "Copay"}, {"apps": ["ebook2cw"], "developer_validation":
+        "unproven", "icon_url": "", "media": [], "origin": "bh1scw", "package_name":
+        "ebook2cw", "publisher": "FJKong", "sections": [{"featured": true, "name":
+        "books-and-reference"}], "summary": "ebook2cw - convert ebooks to Morse MP3s/OGGs",
+        "title": "ebook2cw"}, {"apps": ["gitkraken"], "developer_validation": "verified",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/1.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/1.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/pull-requests_1oUC7KR.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/banner_wDoKy9V.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/banner-icon_vWkDBG3.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/graph.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/merge-conflict.png"}],
+        "origin": "gitkraken", "package_name": "gitkraken", "publisher": "gitkraken",
+        "sections": [{"featured": true, "name": "development"}], "summary": "For repo
+        management, in-app code editing & issue tracking.", "title": "GitKraken"},
+        {"apps": ["bitpay"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/256x256_6u0RIUd.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/256x256_6u0RIUd.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/linux-image-bitpay1.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/linux-image-bitpay2.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/linux-image-bitpay3.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/linux-image-bitpay4.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/linux-image-bitpay5.png"}],
+        "origin": "gabrielbitpay", "package_name": "bitpay", "publisher": "BitPay",
+        "sections": [{"featured": true, "name": "finance"}], "summary": "A Secure
+        Bitcoin Wallet", "title": "BitPay"}, {"apps": ["config-merge", "mirror", "update-source",
+        "groups", "help", "deploy", "java", "indexer", "sync", "projadm", "opengrok",
+        "reindex-project"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/03/icon.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/03/icon.png"}],
+        "origin": "ondra", "package_name": "opengrok", "publisher": "Ondrej Kubik",
+        "sections": [{"featured": true, "name": "books-and-reference"}], "summary":
+        "OpenGrok is a fast and usable source code search and cross reference engine,
+        written in Java", "title": "{OpenGrok"}, {"apps": ["notepadqq"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/icon.svg_7Eenexu.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/icon.svg_7Eenexu.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/screen_edited.png"}],
+        "origin": "danieleds", "package_name": "notepadqq", "publisher": "Daniele
+        Di Sarli", "sections": [{"featured": true, "name": "development"}, {"featured":
+        false, "name": "productivity"}], "summary": "A Notepad++-like editor for Linux.",
+        "title": "notepadqq"}, {"apps": [], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2016/05/icon_7.png", "media":
+        [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/05/icon_7.png"}],
+        "origin": "elopio", "package_name": "keepassx-elopio", "publisher": "Leo Arias",
+        "sections": [{"featured": true, "name": "security"}], "summary": "KeePassX
+        is a cross platform password safe", "title": "keepassx-elopio"}, {"apps":
+        ["mjpg-streamer"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/webcam.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/webcam.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/streamer.png"}],
+        "origin": "ogra", "package_name": "mjpg-streamer", "publisher": "Oliver Grawert",
+        "sections": [{"featured": true, "name": "photo-and-video"}], "summary": "UVC
+        webcam streaming tool", "title": "mjpg-streamer"}, {"apps": ["intellij-idea-ultimate"],
+        "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/10/logo_zjwX5FR.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/10/logo_zjwX5FR.png"},
+        {"height": 705, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/08/idea_overview_2_copy.png",
+        "width": 1008}], "origin": "jetbrains", "package_name": "intellij-idea-ultimate",
+        "publisher": "jetbrains", "sections": [{"featured": true, "name": "development"}],
+        "summary": "Capable & Ergonomic Java IDE for Enterprise, Web & Mobile Development",
+        "title": "IDEA Ultimate"}, {"apps": ["cacher"], "developer_validation": "verified",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/ubuntu-login.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/ubuntu-login.png"},
+        {"height": 640, "type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/10/snapcraft_bg.png",
+        "width": 1920}, {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/cacher-demo.gif"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/full-featured.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/labels.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/editors.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/teams.png"}],
+        "origin": "cacherapp", "package_name": "cacher", "publisher": "Penguin Labs,
+        LLC", "sections": [{"featured": true, "name": "development"}], "summary":
+        "Cacher is a code snippet library for professional developers. Use it to build
+        a technical knowledge base for you and your team.", "title": "Cacher"}, {"apps":
+        ["mpv"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/08/mpv.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/08/mpv.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/08/Selection_008_LKgCxuk.png"}],
+        "origin": "casept", "package_name": "mpv", "publisher": "David Paskevic",
+        "sections": [{"featured": true, "name": "photo-and-video"}], "summary": "a
+        free, open source, and cross-platform media player.", "title": "mpv"}, {"apps":
+        ["webstorm"], "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/WebStorm_1282x.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/WebStorm_1282x.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/webstorm-on-linux.png"}],
+        "origin": "jetbrains", "package_name": "webstorm", "publisher": "jetbrains",
+        "sections": [{"featured": true, "name": "development"}], "summary": "Powerful
+        IDE for modern JavaScript development", "title": "WebStorm"}, {"apps": ["codebreakers"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/codebreakers.png",
+        "media": [{"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/ScreenShot2.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/Screenshot3.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/Screenshot1.png"},
+        {"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/codebreakers.png"}],
+        "origin": "vagueentertainment", "package_name": "codebreakers", "publisher":
+        "Vague Entertainment", "sections": [{"featured": true, "name": "games"}],
+        "summary": "Guess the code and unlock RogueBot Central", "title": "codebreakers"},
+        {"apps": ["brackets"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/07/brackets_256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/07/brackets_256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/10/Screenshot_from_2017-10-18_12-32-23.png"}],
+        "origin": "snapcrafters", "package_name": "brackets", "publisher": "Snapcrafters",
+        "sections": [{"featured": true, "name": "development"}], "summary": "Brackets
+        is a modern code editor for HTML, CSS and JavaScript.", "title": "Brackets"},
+        {"apps": ["mpv"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/04/mpv-256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/04/mpv-256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/08/Selection_008.png"}],
+        "origin": "casept", "package_name": "mpv-casept", "publisher": "David Paskevic",
+        "sections": [{"featured": true, "name": "photo-and-video"}], "summary": "DEPRECEATED.
+        USE THE mpv SNAP INSTEAD.", "title": "mpv-casept"}, {"apps": ["insomnia"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/04/twitter-card-icon.png",
+        "media": [{"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/main.png"},
+        {"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/04/twitter-card-icon.png"}],
+        "origin": "gschier1990", "package_name": "insomnia", "publisher": "Gregory
+        Schier", "sections": [{"featured": true, "name": "development"}], "summary":
+        "Insomnia REST Client", "title": "Insomnia"}, {"apps": ["aldo"], "developer_validation":
+        "unproven", "icon_url": "", "media": [], "origin": "bh1scw", "package_name":
+        "aldo", "publisher": "FJKong", "sections": [{"featured": true, "name": "education"}],
+        "summary": "Aldo is a morse code learning tool released under GPL.", "title":
+        "aldo"}, {"apps": ["atomify"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2017/06/atomify_logo_256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/06/atomify_logo_256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/08/atomify.png"}],
+        "origin": "ovilab", "package_name": "atomify", "publisher": "Ovilab", "sections":
+        [{"featured": true, "name": "science"}], "summary": "Atomify LAMMPS", "title":
+        "Atomify LAMMPS"}, {"apps": ["sunwait"], "developer_validation": "unproven",
+        "icon_url": "", "media": [], "origin": "popey", "package_name": "sunwait",
+        "publisher": "Alan Pope", "sections": [{"featured": true, "name": "news-and-weather"},
+        {"featured": false, "name": "science"}], "summary": "Sunwait is a program
+        for calculating sunrise and sunset", "title": "Sunwait"}, {"apps": ["irssi"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/07/256irssi.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/07/256irssi.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/07/Screenshot_from_2018-07-02_14-27-15.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/07/Screenshot_from_2018-07-02_14-26-01.png"}],
+        "origin": "snapcrafters", "package_name": "irssi", "publisher": "Snapcrafters",
+        "sections": [{"featured": false, "name": "social"}], "summary": "The IRC client
+        of the future", "title": "irssi"}, {"apps": ["skrifa"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/12/icon_24.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/12/icon_24.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/Screenshot_from_2017-01-06_10-27-42.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/Screenshot_from_2017-01-06_10-29-26.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/Screenshot_from_2017-01-06_10-29-48.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/Screenshot_from_2017-01-06_10-30-02.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/Screenshot_from_2017-01-07_18-42-53.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/Screenshot_from_2017-01-07_18-43-19.png"}],
+        "origin": "hyuchia", "package_name": "skrifa", "publisher": "Hyuchia Diego",
+        "sections": [{"featured": false, "name": "productivity"}], "summary": "A simple
+        word processor built with web technologies", "title": "Skrifa"}, {"apps":
+        ["bw"], "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/256x256_I95tSNJ.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/256x256_I95tSNJ.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/Capture.PNG"}],
+        "origin": "bitwarden", "package_name": "bw", "publisher": "8bit Solutions
+        LLC", "sections": [{"featured": false, "name": "utilities"}], "summary": "A
+        secure and free password manager for all of your devices.", "title": "Bitwarden
+        CLI"}, {"apps": ["clion"], "developer_validation": "verified", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/clion.ico.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/clion.ico.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/Screen_Shot_2017-12-20_at_19.40.03.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/Screen_Shot_2017-12-20_at_20.37.09.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/Screen_Shot_2017-12-20_at_20.30.54.png"}],
+        "origin": "jetbrains", "package_name": "clion", "publisher": "jetbrains",
+        "sections": [{"featured": false, "name": "development"}], "summary": "A cross-platform
+        IDE for C and C++", "title": "CLion"}, {"apps": ["howdoi"], "developer_validation":
+        "unproven", "icon_url": "", "media": [], "origin": "simosx", "package_name":
+        "howdoi", "publisher": "Simos Xenitellis", "sections": [{"featured": false,
+        "name": "books-and-reference"}], "summary": "instant coding answers via the
+        command line", "title": "howdoi"}, {"apps": ["pycharm-educational"], "developer_validation":
+        "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/PyCharmEdu256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/PyCharmEdu256.png"}],
+        "origin": "jetbrains", "package_name": "pycharm-educational", "publisher":
+        "jetbrains", "sections": [{"featured": false, "name": "development"}], "summary":
+        "Easy and Professional Tool to Learn & Teach Programming with Python", "title":
+        "PyCharm EDU"}, {"apps": ["monento"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/icon_256x256_6tATclo.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/icon_256x256_6tATclo.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/1_Personal_finances.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/2_Track_money.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/3_Find_out_expenses.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/4_Know_how_much.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/5_Sync_N69FzV9.png"}],
+        "origin": "ladnysoft", "package_name": "monento", "publisher": "LadnySoft",
+        "sections": [{"featured": false, "name": "finance"}], "summary": "Cross-platform
+        app for tracking personal finances with encrypted data syncing.", "title":
+        "Monento"}, {"apps": ["telegram-cli"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/04/telegram-cli-icon1.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/04/telegram-cli-icon1.png"}],
+        "origin": "marius-quabeck", "package_name": "telegram-cli", "publisher": "Marius
+        Quabeck", "sections": [{"featured": false, "name": "social"}], "summary":
+        "Command-line interface for Telegram. Uses the readline interface.", "title":
+        "telegram-cli"}, {"apps": ["code-insiders", "url-handler"], "developer_validation":
+        "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/code512.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/code512.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/home-screenshot-linux.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/intellisense_b.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/peek_b.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/debug_b.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/git_b.png"}],
+        "origin": "vscode", "package_name": "code-insiders", "publisher": "Visual
+        Studio Code", "sections": [{"featured": false, "name": "development"}], "summary":
+        "Code editing. Redefined.", "title": "Visual Studio Code - Insiders"}, {"apps":
+        [], "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/07/ffmpeg256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/07/ffmpeg256.png"}],
+        "origin": "canonical", "package_name": "chromium-ffmpeg", "publisher": "Canonical",
+        "sections": [], "summary": "FFmpeg codecs (free and proprietary) for use by
+        third-party browser snaps", "title": "Chromium FFmpeg codecs"}, {"apps": ["gedit"],
+        "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/07/gedit.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/07/gedit.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/07/Screenshot_from_2017-07-19_15-25-40.png"}],
+        "origin": "canonical", "package_name": "gedit", "publisher": "Canonical",
+        "sections": [{"featured": false, "name": "development"}, {"featured": false,
+        "name": "productivity"}], "summary": "Edit text files", "title": "Text Editor"},
+        {"apps": ["standard-notes"], "developer_validation": "verified", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/Blue-Rounded-512.png",
+        "media": [{"height": 512, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/Blue-Rounded-512.png",
+        "width": 512}, {"height": 1060, "type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/Banner.png",
+        "width": 3180}, {"height": 658, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/Screenshot_1.png",
+        "width": 1170}, {"height": 658, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/Screenshot_2.png",
+        "width": 1170}, {"height": 658, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/Screenshot_3.png",
+        "width": 1170}, {"height": 658, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/Screenshot_4.png",
+        "width": 1170}], "origin": "standardnotes", "package_name": "standard-notes",
+        "publisher": "Standard Notes", "sections": [{"featured": false, "name": "productivity"}],
+        "summary": "Encrypted note-taking for all your devices.", "title": "Standard
+        Notes"}, {"apps": ["umbrello"], "developer_validation": "verified", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/umbrello.svg.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/umbrello.svg.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/umbrello.png"}],
+        "origin": "kde", "package_name": "umbrello", "publisher": "KDE", "sections":
+        [{"featured": false, "name": "development"}], "summary": "UML modelling tool
+        and code generator", "title": "Umbrello"}, {"apps": ["rider"], "developer_validation":
+        "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/snap-icon.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/snap-icon.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/rider1.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/rider2.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/rider3.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/rider0.png"}],
+        "origin": "jetbrains", "package_name": "rider", "publisher": "jetbrains",
+        "sections": [{"featured": false, "name": "development"}, {"featured": false,
+        "name": "utilities"}], "summary": "A fast & powerful cross-platform .NET IDE",
+        "title": "Rider"}, {"apps": ["kate"], "developer_validation": "verified",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/10/kate.svg.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/10/kate.svg.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/kate.png"}],
+        "origin": "kde", "package_name": "kate", "publisher": "KDE", "sections": [],
+        "summary": "KDE Advanced Text Editor", "title": "kate"}, {"apps": [], "developer_validation":
+        "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/snapd.png",
+        "media": [{"height": 460, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/snapd.png",
+        "width": 460}, {"height": 648, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/Screenshot_20190924_115756_hLcyetO.png",
+        "width": 956}, {"height": 648, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/Screenshot_20190924_115824_2v3y6l8.png",
+        "width": 956}, {"height": 834, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/Screenshot_20190924_115055_Uuq7KIb.png",
+        "width": 1023}, {"height": 648, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/Screenshot_20190924_125944.png",
+        "width": 956}], "origin": "canonical", "package_name": "snapd", "publisher":
+        "Canonical", "sections": [], "summary": "Background service that manages and
+        maintains installed snaps", "title": "snapd"}, {"apps": ["iwspy", "iwconfig",
+        "rfkill", "iwgetid", "iwpriv", "iw", "iwevent"], "developer_validation": "verified",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/icon_19.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/icon_19.png"}],
+        "origin": "canonical", "package_name": "wireless-tools", "publisher": "Canonical",
+        "sections": [], "summary": "Tools for manipulating Linux Wireless Extensions",
+        "title": "wireless-tools"}, {"apps": ["goland"], "developer_validation": "verified",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/go_1282x.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/go_1282x.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/go_overview.png"}],
+        "origin": "jetbrains", "package_name": "goland", "publisher": "jetbrains",
+        "sections": [{"featured": false, "name": "development"}], "summary": "A Clever
+        IDE to Go", "title": "GoLand"}, {"apps": ["space"], "developer_validation":
+        "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/ezgif.com-gif-maker.png",
+        "media": [{"height": 512, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/ezgif.com-gif-maker.png",
+        "width": 512}, {"height": 1860, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/home_for_teams.png",
+        "width": 2880}, {"height": 1638, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/collaborate_on_code_in_place.png",
+        "width": 2880}, {"height": 1736, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/issue_tracking.png",
+        "width": 2880}], "origin": "jetbrains", "package_name": "space", "publisher":
+        "jetbrains", "sections": [{"featured": false, "name": "development"}], "summary":
+        "Desktop Application for JetBrains Space", "title": "Space"}, {"apps": ["irccloud"],
+        "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/icon_fvVGr52.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/icon_fvVGr52.png"},
+        {"height": 1296, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/4a4675a8-7246-46b6-9d64-183a990b49f9.png",
+        "width": 2340}, {"height": 1296, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/e6ffefaa-8ecc-402f-8037-1b72112b43aa.png",
+        "width": 2340}, {"height": 1296, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/e2d56fdb-1c99-4099-9e5a-5af17cc5885b.png",
+        "width": 2340}], "origin": "irccloud", "package_name": "irccloud", "publisher":
+        "IRCCloud", "sections": [{"featured": false, "name": "productivity"}, {"featured":
+        false, "name": "social"}], "summary": "An IRC client with a future. Stay connected,
+        chat from anywhere, and never miss a message", "title": "IRCCloud"}, {"apps":
+        ["dotnet"], "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/msft.net_256_8NLBkoS.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/msft.net_256_8NLBkoS.png"}],
+        "origin": "dotnetcore", "package_name": "dotnet-sdk", "publisher": "Microsoft
+        .NET Core", "sections": [{"featured": false, "name": "development"}], "summary":
+        "Develop high performance applications in less time, on any platform.", "title":
+        ".NET Core SDK"}, {"apps": ["qmi-network", "qmicli", "mbim-network", "mbimcli",
+        "mmcli"], "developer_validation": "verified", "icon_url": "", "media": [],
+        "origin": "canonical", "package_name": "modem-manager", "publisher": "Canonical",
+        "sections": [{"featured": false, "name": "devices-and-iot"}], "summary": "ModemManager
+        is a service which controls mobile broadband", "title": "modem-manager"},
+        {"apps": [], "developer_validation": "verified", "icon_url": "", "media":
+        [], "origin": "canonical", "package_name": "ofono", "publisher": "Canonical",
+        "sections": [], "summary": "Mobile telephony daemon", "title": "ofono"}, {"apps":
+        ["shyaml", "snap-revision", "bugsurfer", "setup-snap-repo", "flightschedule"],
+        "developer_validation": "verified", "icon_url": "", "media": [], "origin":
+        "canonical", "package_name": "se-dev-tools", "publisher": "Canonical", "sections":
+        [], "summary": "A set of utilities that help make working with our team snaps
+        easier", "title": "se-dev-tools"}, {"apps": [], "developer_validation": "verified",
+        "icon_url": "", "media": [], "origin": "canonical", "package_name": "gucharmap-udt",
+        "publisher": "Canonical", "sections": [], "summary": "Unicode character picker
+        and font browser", "title": "gucharmap-udt"}, {"apps": ["simple-obex-agent"],
+        "developer_validation": "verified", "icon_url": "", "media": [], "origin":
+        "canonical", "package_name": "bluez-tests", "publisher": "Canonical", "sections":
+        [], "summary": "Set of utilities that are not production ready yet help in
+        testing", "title": "bluez-tests"}, {"apps": ["alsa-utils", "udisks2", "run",
+        "plainbox", "tpm", "pulseaudio", "network-manager", "bluez", "wifi-ap", "upower",
+        "modem-manager", "media-hub", "wireless-tools"], "developer_validation": "verified",
+        "icon_url": "", "media": [], "origin": "canonical", "package_name": "canonical-se-engineering-tests",
+        "publisher": "Canonical", "sections": [], "summary": "Canonical System Enablement
+        Engineering Test cases", "title": "canonical-se-engineering-tests"}, {"apps":
+        ["qr-code-generator-desktop"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/icon_P7afCqs.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/icon_P7afCqs.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/screenshot-1_sjeP5p2.png"}],
+        "origin": "studiolacosanostra", "package_name": "qr-code-generator-desktop",
+        "publisher": "Studio La Cosa Nostra", "sections": [{"featured": false, "name":
+        "utilities"}], "summary": "Create custom QR Codes. You can save them as PNG
+        image. You can change the size of the image.", "title": "QR Code Generator"},
+        {"apps": ["codenamelt"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/icon_256x256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/icon_256x256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/screenshot_snap.png"}],
+        "origin": "eri0o", "package_name": "codenamelt", "publisher": "erico_pt",
+        "sections": [{"featured": false, "name": "games"}], "summary": "A pixelart
+        game where you have to run without getting caught by evil agents.", "title":
+        "codenamelt"}, {"apps": ["codedoc"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/codedoc-256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/codedoc-256.png"}],
+        "origin": "michaelrsweet", "package_name": "codedoc", "publisher": "Michael
+        Sweet", "sections": [{"featured": false, "name": "utilities"}], "summary":
+        "Code documentation utility.", "title": "codedoc"}, {"apps": ["ampareqrcodelinux"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/qr-code.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/qr-code.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/Screenshot_2018-02-11_01-50-38.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/Screenshot_2018-02-11_01-50-30.png"}],
+        "origin": "juthawong", "package_name": "ampareqrcodelinux", "publisher": "Juthawong
+        Naisanguansee", "sections": [], "summary": "Create Your Own QR Code From Any
+        Text and Save", "title": "Ampare QR Code Creator"}, {"apps": ["prettier"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/prettier-icon-dark.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/prettier-icon-dark.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/screenshot_nFeUCLQ.png"}],
+        "origin": "sangbum", "package_name": "prettier", "publisher": "Sangbum Kim",
+        "sections": [], "summary": "Prettier is an opinionated code formatter", "title":
+        "prettier"}, {"apps": ["scc"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/icon_PvPKbUH.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/icon_PvPKbUH.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/screenshot_bwlDNiR.png"}],
+        "origin": "felicianotech", "package_name": "scc", "publisher": "Ricardo N
+        Feliciano", "sections": [{"featured": false, "name": "development"}], "summary":
+        "scc is a very fast & accurate code counter counting lines of code by language.",
+        "title": "scc"}, {"apps": ["line-calc"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/03/icon_7.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/03/icon_7.png"}],
+        "origin": "quasarapp", "package_name": "line-calc", "publisher": "Andrei Yancovich",
+        "sections": [], "summary": "Utility for counting the number of lines in a
+        project.", "title": "Line Calc"}, {"apps": ["gisto"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/icon_60sKxPN.png",
+        "media": [{"height": 512, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/icon_60sKxPN.png",
+        "width": 512}, {"height": 1600, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/Jx8Tc9s.png",
+        "width": 2560}, {"height": 1600, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/yiEJRNt.png",
+        "width": 2560}, {"height": 1600, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/JtUCsfI.png",
+        "width": 2560}, {"height": 1600, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/Aac48m9.png",
+        "width": 2560}, {"height": 1600, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/bXySAUt.png",
+        "width": 2560}], "origin": "gisto", "package_name": "gisto", "publisher":
+        "Gisto", "sections": [{"featured": false, "name": "development"}, {"featured":
+        false, "name": "productivity"}], "summary": "Code snippet manager, runs on
+        GitHub Gists and adds additional features such as searching, tagging gists
+        with rich code editor.", "title": "Gisto"}, {"apps": ["amparetraceroute"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/04/trace.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/04/trace.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/04/Screenshot_2018-04-19_18-14-20.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/04/Screenshot_2018-04-19_18-13-28.png"}],
+        "origin": "juthawong", "package_name": "amparetraceroute", "publisher": "Juthawong
+        Naisanguansee", "sections": [], "summary": "Trace HTTP Route and Display Result",
+        "title": "Ampare HTTP Trace Route"}, {"apps": ["broker"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/apibillme_copy_tdEZI5g.png",
+        "media": [{"height": 256, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/apibillme_copy_tdEZI5g.png",
+        "width": 256}, {"height": 500, "type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/1500x500.jpeg",
+        "width": 1500}], "origin": "bevanhunt", "package_name": "broker", "publisher":
+        "Bevan Hunt", "sections": [{"featured": false, "name": "server-and-cloud"}],
+        "summary": "Real-time Zero-Code API Server", "title": "broker"}, {"apps":
+        ["cppcheck"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/cppcheck.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/cppcheck.png"}],
+        "origin": "cking-kernel-tools", "package_name": "cppcheck", "publisher": "Colin
+        King", "sections": [{"featured": false, "name": "development"}], "summary":
+        "A tool for static C/C++ code analysis", "title": "cppcheck"}, {"apps": ["zig"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/zig-icon.svg.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/zig-icon.svg.png"}],
+        "origin": "jayschwa", "package_name": "zig", "publisher": "Jay Petacat", "sections":
+        [{"featured": false, "name": "development"}], "summary": "Zig Programming
+        Language", "title": "Zig"}, {"apps": ["packer"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/04/packer-abacao.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/04/packer-abacao.png"}],
+        "origin": "abacao", "package_name": "packer-abacao", "publisher": "Andr\u00e9
+        Ba\u00e7\u00e3o", "sections": [], "summary": "Packer - Build Automated Machine
+        Images", "title": "packer-abacao"}, {"apps": ["cppcheckgui"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/cppcheck-gui.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/cppcheck-gui.png"}],
+        "origin": "gocarlos", "package_name": "cppcheckgui", "publisher": "Carlos
+        Gomes Martinho", "sections": [], "summary": "A tool for static C/C++ code
+        analysis", "title": "cppcheckgui"}, {"apps": ["rdplot"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/PLOT256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/PLOT256.png"}],
+        "origin": "schneider-p", "package_name": "rdplot", "publisher": "Jens Schneider",
+        "sections": [], "summary": "The plotting tool for rate distortion curves in
+        the context of video coding.", "title": "rdplot"}, {"apps": ["amparecssrandomcolor"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/icon_qBUklKz.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/icon_qBUklKz.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/Screenshot_from_2018-09-04_22-29-53.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/Screenshot_from_2018-09-04_22-29-36.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/Screenshot_from_2018-09-04_22-28-59.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/Screenshot_from_2018-09-04_22-28-46.png"}],
+        "origin": "juthawong", "package_name": "amparecssrandomcolor", "publisher":
+        "Juthawong Naisanguansee", "sections": [], "summary": "Random Color with CSS
+        Hexadecimal Code For Next Web Design Idea", "title": "Ampare Random CSS Color"},
+        {"apps": ["puppetry"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/puppetry-256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/puppetry-256.png"},
+        {"height": 400, "type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/main-1x3.png",
+        "width": 1200}, {"height": 720, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/main_VoewqIW.png",
+        "width": 1200}, {"height": 720, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/article-relative-position.png",
+        "width": 1200}, {"height": 720, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/article-report-ok.png",
+        "width": 1200}, {"height": 720, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/article-css-regression.png",
+        "width": 1200}], "origin": "dsheiko", "package_name": "puppetry", "publisher":
+        "Dzmitry Sheiko", "sections": [{"featured": false, "name": "development"},
+        {"featured": false, "name": "utilities"}], "summary": "Puppetry - codeless
+        end-to-end test automation, integrated with CI/CD pipeline", "title": "Puppetry"},
+        {"apps": ["python-vvv", "report", "python-add-root", "python", "report-add-root",
+        "python-v", "pynsource", "python-add-site", "report-add-site"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/G12-Folder-Doc-icon.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/G12-Folder-Doc-icon.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/pynsource-mbp-screen-python.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/pynsource-zoom-line-edit.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/pynsource-ascii_uml.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/2019-03-02_12-15-04-1.gif"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/pynsource-plantuml-2.png"}],
+        "origin": "andybulka", "package_name": "pynsource", "publisher": "Andy", "sections":
+        [{"featured": false, "name": "development"}], "summary": "Pynsource - reverse
+        engineer Python source code into UML", "title": "Pynsource - UML tool for
+        Python"}, {"apps": ["qxmledit"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/qxmledit.svg.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/qxmledit.svg.png"},
+        {"type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/QXmlEdit_Banner_Snap_Store.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/qxmledit-screenshot-800.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/anonymize.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/attribute_filter.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/base64.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/charinfo.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/codepages.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/comparexsd.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/editelement.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/encodings.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/heatmaps.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/relations.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/split.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/structure.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/xsd.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/xslt.png"}],
+        "origin": "frederickjh", "package_name": "qxmledit", "publisher": "Frederick
+        J. Henderson", "sections": [{"featured": false, "name": "development"}, {"featured":
+        false, "name": "utilities"}], "summary": "QXmlEdit is a simple XML editor
+        based on Qt libraries.", "title": "qxmledit"}, {"apps": ["rockscissorspaperlizardspock-snap"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/rockscissorspaperlizardspock-snap.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/rockscissorspaperlizardspock-snap.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/RSPLS-snap_screenshot1.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/RSPLS-snap_screenshot2.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/RSPLS-snap_screenshot3.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/RSPLS-snap_screenshot4.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/RSPLS-snap_screenshot5.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/RSPLS-snap_screenshot6.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/RSPLS-snap_screenshot7.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/RSPLS-snap_screenshot8.png"}],
+        "origin": "phelion", "package_name": "rockscissorspaperlizardspock-snap",
+        "publisher": "pHeLiOn", "sections": [], "summary": "2 player game of a variation
+        of ''Rock, Paper, Scissors''", "title": "rockscissorspaperlizardspock-snap"},
+        {"apps": ["e-tools"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/512.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/512.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/v1.3.6.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/english.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/chinese.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/russian.png"}],
+        "origin": "suremotoo", "package_name": "e-tools", "publisher": "Suremotoo",
+        "sections": [{"featured": false, "name": "development"}], "summary": "A toolbox
+        for developers. Color picker, code formatter, and more", "title": "E-tools"},
+        {"apps": ["gif2flif", "flif", "dflif", "viewflif", "apng2flif"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/index.png",
+        "media": [{"height": 512, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/index.png",
+        "width": 512}], "origin": "nevermine17", "package_name": "flif", "publisher":
+        "Danil Nikolaev", "sections": [{"featured": false, "name": "photo-and-video"},
+        {"featured": false, "name": "utilities"}], "summary": "All the tools you need
+        for the Free Lossless Image Format", "title": "FLIF - Free Lossless Image
+        Format"}, {"apps": ["authenticator"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/icon_6nLCgqR.png",
+        "media": [{"height": 128, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/icon_6nLCgqR.png",
+        "width": 128}], "origin": "jocave", "package_name": "authenticator-joc", "publisher":
+        "Jonathan Cave", "sections": [{"featured": false, "name": "security"}], "summary":
+        "A Two-Factor Authentication application", "title": "authenticator-joc"},
+        {"apps": ["daemon-testnet", "daemon", "cli-regtest", "cli", "tx", "qt-testnet",
+        "daemon-regtest", "cli-testnet", "qt-regtest", "qt"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/ion256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/ion256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/splash.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/multisig-overview.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/blockexplorer.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/commandline-options.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/options.png"}],
+        "origin": "ioncoin", "package_name": "ioncore", "publisher": "Ion coin developer",
+        "sections": [{"featured": false, "name": "finance"}, {"featured": false, "name":
+        "games"}], "summary": "gaming related peer-to-peer network based digital currency",
+        "title": "Ion Digital Currency (Official release)"}, {"apps": ["brackets"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/brackets.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/brackets.png"}],
+        "origin": "cprov", "package_name": "cprov-brackets", "publisher": "Celso Providelo",
+        "sections": [], "summary": "Brackets is a modern code editor for HTML, CSS
+        and JavaScript.", "title": "cprov-brackets"}, {"apps": ["hub"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/icon.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/icon.png"}],
+        "origin": "felicianotech", "package_name": "hub", "publisher": "Ricardo N
+        Feliciano", "sections": [{"featured": false, "name": "development"}], "summary":
+        "hub is a command-line wrapper for git that makes you better at GitHub.",
+        "title": "hub"}, {"apps": ["vokoscreen-ng"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/vokoscreen-ng.png",
+        "media": [{"height": 256, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/vokoscreen-ng.png",
+        "width": 256}, {"height": 483, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/02/Screenshot_from_2020-02-06_08-53-40.png",
+        "width": 730}, {"height": 483, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/02/Screenshot_from_2020-02-06_08-54-09.png",
+        "width": 730}, {"height": 483, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/02/Screenshot_from_2020-02-06_08-54-35.png",
+        "width": 730}], "origin": "popey", "package_name": "vokoscreen-ng", "publisher":
+        "Alan Pope", "sections": [{"featured": false, "name": "photo-and-video"},
+        {"featured": false, "name": "utilities"}], "summary": "vokoscreenNG", "title":
+        "vokoscreenNG"}, {"apps": ["color-picker"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/app.png",
+        "media": [{"height": 512, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/app.png",
+        "width": 512}, {"height": 708, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/pic_1.png",
+        "width": 530}, {"height": 705, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/pic_2.png",
+        "width": 929}], "origin": "keshavnrj", "package_name": "color-picker", "publisher":
+        "keshavbhatt", "sections": [{"featured": false, "name": "development"}, {"featured":
+        false, "name": "utilities"}], "summary": "A colour picker and colour editor
+        for web designers and digital artists", "title": "Color Picker"}, {"apps":
+        ["azimuth"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/azimuth480.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/azimuth480.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/Screenshot_20190412_214356.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/Screenshot_20190412_214437.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/Screenshot_20190412_214544.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/Screenshot_20190412_214704-1.png"}],
+        "origin": "popey", "package_name": "azimuth", "publisher": "Alan Pope", "sections":
+        [{"featured": false, "name": "games"}], "summary": "Azimuth - A metroidvania
+        with vector graphics", "title": "azimuth"}, {"apps": [], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/icon256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/icon256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/osddm.png"}],
+        "origin": "vs", "package_name": "osddm", "publisher": "vasilisc", "sections":
+        [{"featured": false, "name": "development"}], "summary": "Oracle SQL Developer
+        Data Modeler", "title": "osddm"}, {"apps": ["barriers", "barrierc", "barrier"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/08/icon.svg_JtFjzqW.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/08/icon.svg_JtFjzqW.png"}],
+        "origin": "adrianceleste", "package_name": "barrier", "publisher": "Adrian
+        Lucr\u00e8ce C\u00e9leste", "sections": [{"featured": false, "name": "productivity"}],
+        "summary": "Barrier - Share mouse and keyboard over the local network", "title":
+        "barrier"}, {"apps": ["sectrain"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/st-snapico.png",
+        "media": [{"height": 493, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/st-snapico.png",
+        "width": 493}, {"height": 500, "type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/st-banner.png",
+        "width": 1500}, {"height": 974, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/st-xss.png",
+        "width": 1804}, {"height": 974, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/st-home.png",
+        "width": 1804}, {"height": 974, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/st-install.png",
+        "width": 1804}, {"height": 974, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/st-py.png",
+        "width": 1804}], "origin": "joemcmanus", "package_name": "sectrain", "publisher":
+        "Joe McManus", "sections": [{"featured": false, "name": "education"}, {"featured":
+        false, "name": "security"}], "summary": "A training tool displaying some techniques
+        for secure web app development", "title": "sectrain"}, {"apps": ["yquake2",
+        "yquake2-launch"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/quake2.svg.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/quake2.svg.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/Bildschirmfoto_von_2018-08-25_17-09-46.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/Bildschirmfoto_von_2018-08-25_17-10-11.png"}],
+        "origin": "beidl", "package_name": "yamagi-quake2-beidl", "publisher": "Alfred
+        E. Neumayer", "sections": [], "summary": "An enhanced version of id Software''s
+        Quake II.", "title": "Yamagi Quake II"}, {"apps": ["kimitzu-client"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/icon_vwLGEQ1.png",
+        "media": [{"height": 512, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/icon_vwLGEQ1.png",
+        "width": 512}, {"height": 660, "type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/full-blue.png",
+        "width": 1980}, {"height": 1080, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/Screenshot_from_2020-01-22_09-53-27.png",
+        "width": 1920}, {"height": 1080, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/Screenshot_from_2020-01-22_12-38-04.png",
+        "width": 1920}], "origin": "kimitzu", "package_name": "kimitzu-client", "publisher":
+        "Kimitzu Foundation", "sections": [{"featured": false, "name": "utilities"}],
+        "summary": "Kimitzu Client: A free market for services", "title": "Kimitzu"},
+        {"apps": ["bussard"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/03/bussard_256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/03/bussard_256.png"}],
+        "origin": "popey", "package_name": "bussard", "publisher": "Alan Pope", "sections":
+        [], "summary": "Bussard", "title": "bussard"}, {"apps": ["gamecake", "grd",
+        "jam", "midi"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/09/gamecake.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/09/gamecake.png"},
+        {"height": 640, "type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/gcake.png",
+        "width": 1920}, {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/09/20170811_134606.png"},
+        {"height": 485, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/screen_2McWHe5.png",
+        "width": 648}, {"height": 512, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/screen_qhfNjQZ.png",
+        "width": 911}, {"height": 744, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/screen_6b6P2KQ.png",
+        "width": 1349}, {"height": 1056, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/screen_qlUaH1Y.png",
+        "width": 1920}], "origin": "xriss", "package_name": "gamecake", "publisher":
+        "kriss", "sections": [{"featured": false, "name": "development"}, {"featured":
+        false, "name": "games"}], "summary": "a single exe cross platform Lua game
+        engine", "title": "gamecake"}, {"apps": ["epictask"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/icon-256x256.png",
+        "media": [{"type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/epictask-banner.png"},
+        {"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/icon-256x256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/epictask-screen-01.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/epictask-screen-02.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/epictask-screen-03.png"}],
+        "origin": "densebrain", "package_name": "epictask", "publisher": "Densebrain,
+        Inc", "sections": [{"featured": false, "name": "development"}, {"featured":
+        false, "name": "utilities"}], "summary": "*Github* issues are your bitch!",
+        "title": "Epictask"}, {"apps": ["dspatcher"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/heartbeat.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/heartbeat.png"},
+        {"height": 723, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/08/DSPatcher_-_Screenshot.png",
+        "width": 1161}], "origin": "marcustomlinson", "package_name": "dspatcher",
+        "publisher": "Marcus Tomlinson", "sections": [{"featured": false, "name":
+        "music-and-audio"}, {"featured": false, "name": "science"}], "summary": "Cross-Platform
+        Graphical Tool for DSPatch", "title": "dspatcher"}]}, "_links": {"last": {"href":
+        "https://api.snapcraft.io/api/v1/snaps/search?q=code&size=100&page=3&scope=wide&confinement=strict%2Cclassic&fields=package_name%2Ctitle%2Csummary%2Cicon_url%2Cmedia%2Cpublisher%2Cdeveloper_validation%2Corigin%2Capps%2Csections&arch=wide"},
+        "next": {"href": "https://api.snapcraft.io/api/v1/snaps/search?q=code&size=100&page=2&scope=wide&confinement=strict%2Cclassic&fields=package_name%2Ctitle%2Csummary%2Cicon_url%2Cmedia%2Cpublisher%2Cdeveloper_validation%2Corigin%2Capps%2Csections&arch=wide"},
+        "self": {"href": "https://api.snapcraft.io/api/v1/snaps/search?q=code&size=100&page=1&scope=wide&confinement=strict%2Cclassic&fields=package_name%2Ctitle%2Csummary%2Cicon_url%2Cmedia%2Cpublisher%2Cdeveloper_validation%2Corigin%2Capps%2Csections&arch=wide"}},
+        "total": 287}'
+    headers:
+      Age:
+      - '1071'
+      Content-Length:
+      - '73481'
+      Content-Type:
+      - application/hal+json
+      Date:
+      - Wed, 19 Feb 2020 13:02:56 GMT
+      Server:
+      - gunicorn/19.7.1
+      Snap-Store-Version:
+      - '18'
+      Vary:
+      - X-Ubuntu-Store, X-Ubuntu-Series, X-Ubuntu-Architecture
+      Via:
+      - 1.1 juju-7794b8-prod-ols-snap-store-indep-1655 (squid/3.5.27)
+      X-Cache:
+      - HIT from juju-7794b8-prod-ols-snap-store-indep-1655
+      X-Cache-Lookup:
+      - HIT from juju-7794b8-prod-ols-snap-store-indep-1655:3128
+      X-Request-Id:
+      - 59C57682875A0A325C8101BB5E4D31FC366CB62
+      X-VCS-Revision:
+      - 3476d7a
+      X-View-Name:
+      - snapdevicegw.webapi_search.snap_search
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+      X-Ubuntu-Architecture:
+      - wide
+      X-Ubuntu-Series:
+      - '16'
+    method: GET
+    uri: https://api.snapcraft.io/api/v1/snaps/search?q=code&size=10&page=1&scope=wide&confinement=strict%2Cclassic&fields=package_name%2Ctitle%2Csummary%2Cicon_url%2Cmedia%2Cpublisher%2Cdeveloper_validation%2Corigin%2Capps%2Csections&arch=wide
+  response:
+    body:
+      string: '{"_embedded": {"clickindex:package": [{"apps": ["code", "url-handler"],
+        "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/code_ozwVHSV.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/code_ozwVHSV.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/09/home-screenshot-linux.png"}],
+        "origin": "vscode", "package_name": "code", "publisher": "Visual Studio Code",
+        "sections": [{"featured": false, "name": "development"}], "summary": "Code
+        editing. Redefined.", "title": "Visual Studio Code"}, {"apps": ["subl"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/03/sublime-text.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/03/sublime-text.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/03/linux.png"}],
+        "origin": "snapcrafters", "package_name": "sublime-text", "publisher": "Snapcrafters",
+        "sections": [{"featured": true, "name": "development"}], "summary": "A sophisticated
+        text editor for code, markup and prose.", "title": "Sublime Text"}, {"apps":
+        ["pycharm-community"], "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/PyCharmCore256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/PyCharmCore256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/pycharm_com_general.png"}],
+        "origin": "jetbrains", "package_name": "pycharm-community", "publisher": "jetbrains",
+        "sections": [{"featured": true, "name": "development"}], "summary": "Python
+        IDE for Professional Developers", "title": "PyCharm CE"}, {"apps": ["android-studio"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/03/rsz_android_studio_icon.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/03/rsz_android_studio_icon.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/03/android-studio.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/Screenshot_20190418_002828.png"}],
+        "origin": "snapcrafters", "package_name": "android-studio", "publisher": "Snapcrafters",
+        "sections": [{"featured": true, "name": "development"}, {"featured": true,
+        "name": "featured"}], "summary": "The IDE for Android", "title": "Android
+        Studio"}, {"apps": ["riot-web"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/icon_Jfu5bEq.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/icon_Jfu5bEq.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/Screenshot_from_2019-05-29_22-37-35.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/home-communication.png"}],
+        "origin": "popey", "package_name": "riot-web", "publisher": "Alan Pope", "sections":
+        [{"featured": true, "name": "featured"}], "summary": "Communicate the way
+        you want with Riot", "title": "Riot"}, {"apps": ["npm", "desktop-launch"],
+        "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/nr-hex_1.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/nr-hex_1.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/knol.png"}],
+        "origin": "noderedteam", "package_name": "node-red", "publisher": "Node-RED-Team",
+        "sections": [{"featured": false, "name": "development"}, {"featured": true,
+        "name": "devices-and-iot"}], "summary": "Low-code programming for event-driven
+        applications", "title": "Node-RED"}, {"apps": ["docker", "machine", "compose",
+        "help"], "developer_validation": "verified", "icon_url": "", "media": [],
+        "origin": "canonical", "package_name": "docker", "publisher": "Canonical",
+        "sections": [{"featured": true, "name": "server-and-cloud"}], "summary": "Docker
+        container runtime", "title": "Docker"}, {"apps": ["mindustry"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/mindustry.png",
+        "media": [{"height": 256, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/mindustry.png",
+        "width": 256}, {"height": 1053, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/Screenshot_from_2019-09-22_19-06-24.png",
+        "width": 1920}, {"height": 1167, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/zLgp0A.png",
+        "width": 1905}, {"height": 836, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/wT1_AW.png",
+        "width": 1140}], "origin": "popey", "package_name": "mindustry", "publisher":
+        "Alan Pope", "sections": [{"featured": true, "name": "featured"}, {"featured":
+        false, "name": "games"}], "summary": "A sandbox tower defense game", "title":
+        "Mindustry"}, {"apps": ["bitwarden"], "developer_validation": "verified",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/256x256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/256x256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/04/bitwarden_ubuntu.PNG"}],
+        "origin": "bitwarden", "package_name": "bitwarden", "publisher": "8bit Solutions
+        LLC", "sections": [{"featured": false, "name": "productivity"}, {"featured":
+        true, "name": "security"}, {"featured": false, "name": "utilities"}], "summary":
+        "A secure and free password manager for all of your devices.", "title": "Bitwarden"},
+        {"apps": ["notepad-plus-plus"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/notepad-plus-plus.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/notepad-plus-plus.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/04/screenshot.png"}],
+        "origin": "mmtrt", "package_name": "notepad-plus-plus", "publisher": "Taqi
+        Raza", "sections": [{"featured": true, "name": "development"}], "summary":
+        "Notepad-Plus-Plus is a free source code editor.", "title": "Notepad-Plus-Plus
+        (WINE)"}]}, "_links": {"last": {"href": "https://api.snapcraft.io/api/v1/snaps/search?q=code&size=10&page=29&scope=wide&confinement=strict%2Cclassic&fields=package_name%2Ctitle%2Csummary%2Cicon_url%2Cmedia%2Cpublisher%2Cdeveloper_validation%2Corigin%2Capps%2Csections&arch=wide"},
+        "next": {"href": "https://api.snapcraft.io/api/v1/snaps/search?q=code&size=10&page=2&scope=wide&confinement=strict%2Cclassic&fields=package_name%2Ctitle%2Csummary%2Cicon_url%2Cmedia%2Cpublisher%2Cdeveloper_validation%2Corigin%2Capps%2Csections&arch=wide"},
+        "self": {"href": "https://api.snapcraft.io/api/v1/snaps/search?q=code&size=10&page=1&scope=wide&confinement=strict%2Cclassic&fields=package_name%2Ctitle%2Csummary%2Cicon_url%2Cmedia%2Cpublisher%2Cdeveloper_validation%2Corigin%2Capps%2Csections&arch=wide"}},
+        "total": 287}'
+    headers:
+      Content-Length:
+      - '7387'
+      Content-Type:
+      - application/hal+json
+      Date:
+      - Wed, 19 Feb 2020 13:20:44 GMT
+      Server:
+      - gunicorn/19.7.1
+      Snap-Store-Version:
+      - '18'
+      Vary:
+      - X-Ubuntu-Store, X-Ubuntu-Series, X-Ubuntu-Architecture
+      Via:
+      - 1.1 juju-7794b8-prod-ols-snap-store-indep-1655 (squid/3.5.27)
+      X-Cache:
+      - MISS from juju-7794b8-prod-ols-snap-store-indep-1655
+      X-Cache-Lookup:
+      - MISS from juju-7794b8-prod-ols-snap-store-indep-1655:3128
+      X-Request-Id:
+      - 0AACC05AADEE0A325C8501BB5E4D362B37D0498
+      X-VCS-Revision:
+      - 3476d7a
+      X-View-Name:
+      - snapdevicegw.webapi_search.snap_search
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+      X-Ubuntu-Architecture:
+      - wide
+      X-Ubuntu-Series:
+      - '16'
+    method: GET
+    uri: https://api.snapcraft.io/api/v1/snaps/search?q=code&size=100&page=1&scope=wide&confinement=strict%2Cclassic&fields=package_name%2Ctitle%2Csummary%2Cicon_url%2Cmedia%2Cpublisher%2Cdeveloper_validation%2Corigin%2Capps%2Csections&arch=wide
+  response:
+    body:
+      string: '{"_embedded": {"clickindex:package": [{"apps": ["code", "url-handler"],
+        "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/code_ozwVHSV.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/code_ozwVHSV.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/09/home-screenshot-linux.png"}],
+        "origin": "vscode", "package_name": "code", "publisher": "Visual Studio Code",
+        "sections": [{"featured": false, "name": "development"}], "summary": "Code
+        editing. Redefined.", "title": "Visual Studio Code"}, {"apps": ["subl"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/03/sublime-text.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/03/sublime-text.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/03/linux.png"}],
+        "origin": "snapcrafters", "package_name": "sublime-text", "publisher": "Snapcrafters",
+        "sections": [{"featured": true, "name": "development"}], "summary": "A sophisticated
+        text editor for code, markup and prose.", "title": "Sublime Text"}, {"apps":
+        ["pycharm-community"], "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/PyCharmCore256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/PyCharmCore256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/pycharm_com_general.png"}],
+        "origin": "jetbrains", "package_name": "pycharm-community", "publisher": "jetbrains",
+        "sections": [{"featured": true, "name": "development"}], "summary": "Python
+        IDE for Professional Developers", "title": "PyCharm CE"}, {"apps": ["android-studio"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/03/rsz_android_studio_icon.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/03/rsz_android_studio_icon.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/03/android-studio.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/Screenshot_20190418_002828.png"}],
+        "origin": "snapcrafters", "package_name": "android-studio", "publisher": "Snapcrafters",
+        "sections": [{"featured": true, "name": "development"}, {"featured": true,
+        "name": "featured"}], "summary": "The IDE for Android", "title": "Android
+        Studio"}, {"apps": ["riot-web"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/icon_Jfu5bEq.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/icon_Jfu5bEq.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/Screenshot_from_2019-05-29_22-37-35.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/home-communication.png"}],
+        "origin": "popey", "package_name": "riot-web", "publisher": "Alan Pope", "sections":
+        [{"featured": true, "name": "featured"}], "summary": "Communicate the way
+        you want with Riot", "title": "Riot"}, {"apps": ["npm", "desktop-launch"],
+        "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/nr-hex_1.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/nr-hex_1.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/knol.png"}],
+        "origin": "noderedteam", "package_name": "node-red", "publisher": "Node-RED-Team",
+        "sections": [{"featured": false, "name": "development"}, {"featured": true,
+        "name": "devices-and-iot"}], "summary": "Low-code programming for event-driven
+        applications", "title": "Node-RED"}, {"apps": ["docker", "machine", "compose",
+        "help"], "developer_validation": "verified", "icon_url": "", "media": [],
+        "origin": "canonical", "package_name": "docker", "publisher": "Canonical",
+        "sections": [{"featured": true, "name": "server-and-cloud"}], "summary": "Docker
+        container runtime", "title": "Docker"}, {"apps": ["mindustry"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/mindustry.png",
+        "media": [{"height": 256, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/mindustry.png",
+        "width": 256}, {"height": 1053, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/Screenshot_from_2019-09-22_19-06-24.png",
+        "width": 1920}, {"height": 1167, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/zLgp0A.png",
+        "width": 1905}, {"height": 836, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/wT1_AW.png",
+        "width": 1140}], "origin": "popey", "package_name": "mindustry", "publisher":
+        "Alan Pope", "sections": [{"featured": true, "name": "featured"}, {"featured":
+        false, "name": "games"}], "summary": "A sandbox tower defense game", "title":
+        "Mindustry"}, {"apps": ["bitwarden"], "developer_validation": "verified",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/256x256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/256x256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/04/bitwarden_ubuntu.PNG"}],
+        "origin": "bitwarden", "package_name": "bitwarden", "publisher": "8bit Solutions
+        LLC", "sections": [{"featured": false, "name": "productivity"}, {"featured":
+        true, "name": "security"}, {"featured": false, "name": "utilities"}], "summary":
+        "A secure and free password manager for all of your devices.", "title": "Bitwarden"},
+        {"apps": ["notepad-plus-plus"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/notepad-plus-plus.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/notepad-plus-plus.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/04/screenshot.png"}],
+        "origin": "mmtrt", "package_name": "notepad-plus-plus", "publisher": "Taqi
+        Raza", "sections": [{"featured": true, "name": "development"}], "summary":
+        "Notepad-Plus-Plus is a free source code editor.", "title": "Notepad-Plus-Plus
+        (WINE)"}, {"apps": ["cli", "ghb"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2016/10/handbrake-jz.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/10/handbrake-jz.png"}],
+        "origin": "jz", "package_name": "handbrake-jz", "publisher": "Jacob Zimmermann",
+        "sections": [{"featured": true, "name": "photo-and-video"}], "summary": "The
+        open source video transcoder", "title": "handbrake-jz"}, {"apps": ["gnome-calculator"],
+        "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/07/accessories-calculator.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/07/accessories-calculator.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/07/Screenshot_from_2017-07-19_15-23-11.png"}],
+        "origin": "canonical", "package_name": "gnome-calculator", "publisher": "Canonical",
+        "sections": [{"featured": true, "name": "finance"}, {"featured": false, "name":
+        "utilities"}], "summary": "GNOME Calculator", "title": "GNOME Calculator"},
+        {"apps": ["initcaddy", "restoredb", "backupdb", "mongo"], "developer_validation":
+        "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/icon-256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/icon-256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/Screen_Shot_2016-02-22_at_21.44.26.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/Screen_Shot_2016-02-22_at_21.45.00.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/Screen_Shot_2016-02-22_at_21.45.35.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/Screen_Shot_2016-02-22_at_21.47.10.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/Screen_Shot_2016-02-22_at_21.48.31.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/Screen_Shot_2016-03-09_at_20.15.01.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/Screen_Shot_2016-03-18_at_18.00.07.png"}],
+        "origin": "rocketchat", "package_name": "rocketchat-server", "publisher":
+        "Rocket.Chat", "sections": [{"featured": true, "name": "server-and-cloud"}],
+        "summary": "Group chat server for 100s,  installed in seconds.", "title":
+        "Rocket.Chat Server"}, {"apps": ["intellij-idea-community"], "developer_validation":
+        "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/icon_CE_256_2Qe5uEl.png",
+        "media": [{"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/09/screenshot_Pm7mWCg.png"},
+        {"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/icon_CE_256_2Qe5uEl.png"}],
+        "origin": "jetbrains", "package_name": "intellij-idea-community", "publisher":
+        "jetbrains", "sections": [{"featured": true, "name": "development"}], "summary":
+        "Capable & Ergonomic Java IDE", "title": "IDEA Community"}, {"apps": ["phpstorm"],
+        "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/webide.ico_HA9tBL0.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/webide.ico_HA9tBL0.png"},
+        {"height": 980, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/08/welcome.png",
+        "width": 1554}, {"height": 2105, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/08/overview.png",
+        "width": 3706}], "origin": "jetbrains", "package_name": "phpstorm", "publisher":
+        "jetbrains", "sections": [{"featured": true, "name": "development"}], "summary":
+        "PHP IDE for Professional Development", "title": "PhpStorm"}, {"apps": ["wormhole"],
+        "developer_validation": "unproven", "icon_url": "", "media": [{"type": "screenshot",
+        "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/07/Screenshot_from_2018-07-02_14-23-15.png"}],
+        "origin": "snapcrafters", "package_name": "wormhole", "publisher": "Snapcrafters",
+        "sections": [{"featured": true, "name": "utilities"}], "summary": "get things
+        from one computer to another, safely", "title": "wormhole"}, {"apps": ["copay"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/256x256_6ileytI.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/256x256_6ileytI.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/linux-image-copay1_LrjSusR.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/linux-image-copay2_2PODIzz.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/linux-image-copay3_ugITmgN.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/linux-image-copay4_A0dvFl0.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/linux-image-copay5_4zbhWlR.png"}],
+        "origin": "gabrielbitpay", "package_name": "copay", "publisher": "BitPay",
+        "sections": [{"featured": true, "name": "finance"}], "summary": "A Secure
+        Bitcoin Wallet", "title": "Copay"}, {"apps": ["ebook2cw"], "developer_validation":
+        "unproven", "icon_url": "", "media": [], "origin": "bh1scw", "package_name":
+        "ebook2cw", "publisher": "FJKong", "sections": [{"featured": true, "name":
+        "books-and-reference"}], "summary": "ebook2cw - convert ebooks to Morse MP3s/OGGs",
+        "title": "ebook2cw"}, {"apps": ["gitkraken"], "developer_validation": "verified",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/1.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/1.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/pull-requests_1oUC7KR.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/banner_wDoKy9V.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/banner-icon_vWkDBG3.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/graph.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/merge-conflict.png"}],
+        "origin": "gitkraken", "package_name": "gitkraken", "publisher": "gitkraken",
+        "sections": [{"featured": true, "name": "development"}], "summary": "For repo
+        management, in-app code editing & issue tracking.", "title": "GitKraken"},
+        {"apps": ["bitpay"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/256x256_6u0RIUd.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/256x256_6u0RIUd.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/linux-image-bitpay1.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/linux-image-bitpay2.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/linux-image-bitpay3.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/linux-image-bitpay4.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/linux-image-bitpay5.png"}],
+        "origin": "gabrielbitpay", "package_name": "bitpay", "publisher": "BitPay",
+        "sections": [{"featured": true, "name": "finance"}], "summary": "A Secure
+        Bitcoin Wallet", "title": "BitPay"}, {"apps": ["config-merge", "mirror", "update-source",
+        "groups", "help", "deploy", "java", "indexer", "sync", "projadm", "opengrok",
+        "reindex-project"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/03/icon.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/03/icon.png"}],
+        "origin": "ondra", "package_name": "opengrok", "publisher": "Ondrej Kubik",
+        "sections": [{"featured": true, "name": "books-and-reference"}], "summary":
+        "OpenGrok is a fast and usable source code search and cross reference engine,
+        written in Java", "title": "{OpenGrok"}, {"apps": ["notepadqq"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/icon.svg_7Eenexu.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/icon.svg_7Eenexu.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/screen_edited.png"}],
+        "origin": "danieleds", "package_name": "notepadqq", "publisher": "Daniele
+        Di Sarli", "sections": [{"featured": true, "name": "development"}, {"featured":
+        false, "name": "productivity"}], "summary": "A Notepad++-like editor for Linux.",
+        "title": "notepadqq"}, {"apps": [], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2016/05/icon_7.png", "media":
+        [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/05/icon_7.png"}],
+        "origin": "elopio", "package_name": "keepassx-elopio", "publisher": "Leo Arias",
+        "sections": [{"featured": true, "name": "security"}], "summary": "KeePassX
+        is a cross platform password safe", "title": "keepassx-elopio"}, {"apps":
+        ["mjpg-streamer"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/webcam.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/webcam.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/streamer.png"}],
+        "origin": "ogra", "package_name": "mjpg-streamer", "publisher": "Oliver Grawert",
+        "sections": [{"featured": true, "name": "photo-and-video"}], "summary": "UVC
+        webcam streaming tool", "title": "mjpg-streamer"}, {"apps": ["intellij-idea-ultimate"],
+        "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/10/logo_zjwX5FR.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/10/logo_zjwX5FR.png"},
+        {"height": 705, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/08/idea_overview_2_copy.png",
+        "width": 1008}], "origin": "jetbrains", "package_name": "intellij-idea-ultimate",
+        "publisher": "jetbrains", "sections": [{"featured": true, "name": "development"}],
+        "summary": "Capable & Ergonomic Java IDE for Enterprise, Web & Mobile Development",
+        "title": "IDEA Ultimate"}, {"apps": ["cacher"], "developer_validation": "verified",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/ubuntu-login.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/ubuntu-login.png"},
+        {"height": 640, "type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/10/snapcraft_bg.png",
+        "width": 1920}, {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/cacher-demo.gif"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/full-featured.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/labels.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/editors.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/teams.png"}],
+        "origin": "cacherapp", "package_name": "cacher", "publisher": "Penguin Labs,
+        LLC", "sections": [{"featured": true, "name": "development"}], "summary":
+        "Cacher is a code snippet library for professional developers. Use it to build
+        a technical knowledge base for you and your team.", "title": "Cacher"}, {"apps":
+        ["mpv"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/08/mpv.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/08/mpv.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/08/Selection_008_LKgCxuk.png"}],
+        "origin": "casept", "package_name": "mpv", "publisher": "David Paskevic",
+        "sections": [{"featured": true, "name": "photo-and-video"}], "summary": "a
+        free, open source, and cross-platform media player.", "title": "mpv"}, {"apps":
+        ["webstorm"], "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/WebStorm_1282x.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/WebStorm_1282x.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/webstorm-on-linux.png"}],
+        "origin": "jetbrains", "package_name": "webstorm", "publisher": "jetbrains",
+        "sections": [{"featured": true, "name": "development"}], "summary": "Powerful
+        IDE for modern JavaScript development", "title": "WebStorm"}, {"apps": ["codebreakers"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/codebreakers.png",
+        "media": [{"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/ScreenShot2.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/Screenshot3.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/Screenshot1.png"},
+        {"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/codebreakers.png"}],
+        "origin": "vagueentertainment", "package_name": "codebreakers", "publisher":
+        "Vague Entertainment", "sections": [{"featured": true, "name": "games"}],
+        "summary": "Guess the code and unlock RogueBot Central", "title": "codebreakers"},
+        {"apps": ["brackets"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/07/brackets_256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/07/brackets_256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/10/Screenshot_from_2017-10-18_12-32-23.png"}],
+        "origin": "snapcrafters", "package_name": "brackets", "publisher": "Snapcrafters",
+        "sections": [{"featured": true, "name": "development"}], "summary": "Brackets
+        is a modern code editor for HTML, CSS and JavaScript.", "title": "Brackets"},
+        {"apps": ["mpv"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/04/mpv-256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/04/mpv-256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/08/Selection_008.png"}],
+        "origin": "casept", "package_name": "mpv-casept", "publisher": "David Paskevic",
+        "sections": [{"featured": true, "name": "photo-and-video"}], "summary": "DEPRECEATED.
+        USE THE mpv SNAP INSTEAD.", "title": "mpv-casept"}, {"apps": ["insomnia"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/04/twitter-card-icon.png",
+        "media": [{"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/main.png"},
+        {"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/04/twitter-card-icon.png"}],
+        "origin": "gschier1990", "package_name": "insomnia", "publisher": "Gregory
+        Schier", "sections": [{"featured": true, "name": "development"}], "summary":
+        "Insomnia REST Client", "title": "Insomnia"}, {"apps": ["aldo"], "developer_validation":
+        "unproven", "icon_url": "", "media": [], "origin": "bh1scw", "package_name":
+        "aldo", "publisher": "FJKong", "sections": [{"featured": true, "name": "education"}],
+        "summary": "Aldo is a morse code learning tool released under GPL.", "title":
+        "aldo"}, {"apps": ["atomify"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2017/06/atomify_logo_256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/06/atomify_logo_256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/08/atomify.png"}],
+        "origin": "ovilab", "package_name": "atomify", "publisher": "Ovilab", "sections":
+        [{"featured": true, "name": "science"}], "summary": "Atomify LAMMPS", "title":
+        "Atomify LAMMPS"}, {"apps": ["sunwait"], "developer_validation": "unproven",
+        "icon_url": "", "media": [], "origin": "popey", "package_name": "sunwait",
+        "publisher": "Alan Pope", "sections": [{"featured": true, "name": "news-and-weather"},
+        {"featured": false, "name": "science"}], "summary": "Sunwait is a program
+        for calculating sunrise and sunset", "title": "Sunwait"}, {"apps": ["irssi"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/07/256irssi.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/07/256irssi.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/07/Screenshot_from_2018-07-02_14-27-15.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/07/Screenshot_from_2018-07-02_14-26-01.png"}],
+        "origin": "snapcrafters", "package_name": "irssi", "publisher": "Snapcrafters",
+        "sections": [{"featured": false, "name": "social"}], "summary": "The IRC client
+        of the future", "title": "irssi"}, {"apps": ["skrifa"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/12/icon_24.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/12/icon_24.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/Screenshot_from_2017-01-06_10-27-42.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/Screenshot_from_2017-01-06_10-29-26.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/Screenshot_from_2017-01-06_10-29-48.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/Screenshot_from_2017-01-06_10-30-02.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/Screenshot_from_2017-01-07_18-42-53.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/Screenshot_from_2017-01-07_18-43-19.png"}],
+        "origin": "hyuchia", "package_name": "skrifa", "publisher": "Hyuchia Diego",
+        "sections": [{"featured": false, "name": "productivity"}], "summary": "A simple
+        word processor built with web technologies", "title": "Skrifa"}, {"apps":
+        ["bw"], "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/256x256_I95tSNJ.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/256x256_I95tSNJ.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/Capture.PNG"}],
+        "origin": "bitwarden", "package_name": "bw", "publisher": "8bit Solutions
+        LLC", "sections": [{"featured": false, "name": "utilities"}], "summary": "A
+        secure and free password manager for all of your devices.", "title": "Bitwarden
+        CLI"}, {"apps": ["clion"], "developer_validation": "verified", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/clion.ico.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/clion.ico.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/Screen_Shot_2017-12-20_at_19.40.03.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/Screen_Shot_2017-12-20_at_20.37.09.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/Screen_Shot_2017-12-20_at_20.30.54.png"}],
+        "origin": "jetbrains", "package_name": "clion", "publisher": "jetbrains",
+        "sections": [{"featured": false, "name": "development"}], "summary": "A cross-platform
+        IDE for C and C++", "title": "CLion"}, {"apps": ["howdoi"], "developer_validation":
+        "unproven", "icon_url": "", "media": [], "origin": "simosx", "package_name":
+        "howdoi", "publisher": "Simos Xenitellis", "sections": [{"featured": false,
+        "name": "books-and-reference"}], "summary": "instant coding answers via the
+        command line", "title": "howdoi"}, {"apps": ["pycharm-educational"], "developer_validation":
+        "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/PyCharmEdu256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/PyCharmEdu256.png"}],
+        "origin": "jetbrains", "package_name": "pycharm-educational", "publisher":
+        "jetbrains", "sections": [{"featured": false, "name": "development"}], "summary":
+        "Easy and Professional Tool to Learn & Teach Programming with Python", "title":
+        "PyCharm EDU"}, {"apps": ["monento"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/icon_256x256_6tATclo.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/icon_256x256_6tATclo.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/1_Personal_finances.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/2_Track_money.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/3_Find_out_expenses.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/4_Know_how_much.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/5_Sync_N69FzV9.png"}],
+        "origin": "ladnysoft", "package_name": "monento", "publisher": "LadnySoft",
+        "sections": [{"featured": false, "name": "finance"}], "summary": "Cross-platform
+        app for tracking personal finances with encrypted data syncing.", "title":
+        "Monento"}, {"apps": ["telegram-cli"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/04/telegram-cli-icon1.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/04/telegram-cli-icon1.png"}],
+        "origin": "marius-quabeck", "package_name": "telegram-cli", "publisher": "Marius
+        Quabeck", "sections": [{"featured": false, "name": "social"}], "summary":
+        "Command-line interface for Telegram. Uses the readline interface.", "title":
+        "telegram-cli"}, {"apps": ["code-insiders", "url-handler"], "developer_validation":
+        "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/code512.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/code512.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/home-screenshot-linux.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/intellisense_b.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/peek_b.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/debug_b.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/git_b.png"}],
+        "origin": "vscode", "package_name": "code-insiders", "publisher": "Visual
+        Studio Code", "sections": [{"featured": false, "name": "development"}], "summary":
+        "Code editing. Redefined.", "title": "Visual Studio Code - Insiders"}, {"apps":
+        [], "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/07/ffmpeg256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/07/ffmpeg256.png"}],
+        "origin": "canonical", "package_name": "chromium-ffmpeg", "publisher": "Canonical",
+        "sections": [], "summary": "FFmpeg codecs (free and proprietary) for use by
+        third-party browser snaps", "title": "Chromium FFmpeg codecs"}, {"apps": ["gedit"],
+        "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/07/gedit.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/07/gedit.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/07/Screenshot_from_2017-07-19_15-25-40.png"}],
+        "origin": "canonical", "package_name": "gedit", "publisher": "Canonical",
+        "sections": [{"featured": false, "name": "development"}, {"featured": false,
+        "name": "productivity"}], "summary": "Edit text files", "title": "Text Editor"},
+        {"apps": ["standard-notes"], "developer_validation": "verified", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/Blue-Rounded-512.png",
+        "media": [{"height": 512, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/Blue-Rounded-512.png",
+        "width": 512}, {"height": 1060, "type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/Banner.png",
+        "width": 3180}, {"height": 658, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/Screenshot_1.png",
+        "width": 1170}, {"height": 658, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/Screenshot_2.png",
+        "width": 1170}, {"height": 658, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/Screenshot_3.png",
+        "width": 1170}, {"height": 658, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/Screenshot_4.png",
+        "width": 1170}], "origin": "standardnotes", "package_name": "standard-notes",
+        "publisher": "Standard Notes", "sections": [{"featured": false, "name": "productivity"}],
+        "summary": "Encrypted note-taking for all your devices.", "title": "Standard
+        Notes"}, {"apps": ["umbrello"], "developer_validation": "verified", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/umbrello.svg.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/umbrello.svg.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/umbrello.png"}],
+        "origin": "kde", "package_name": "umbrello", "publisher": "KDE", "sections":
+        [{"featured": false, "name": "development"}], "summary": "UML modelling tool
+        and code generator", "title": "Umbrello"}, {"apps": ["rider"], "developer_validation":
+        "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/snap-icon.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/snap-icon.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/rider1.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/rider2.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/rider3.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/rider0.png"}],
+        "origin": "jetbrains", "package_name": "rider", "publisher": "jetbrains",
+        "sections": [{"featured": false, "name": "development"}, {"featured": false,
+        "name": "utilities"}], "summary": "A fast & powerful cross-platform .NET IDE",
+        "title": "Rider"}, {"apps": ["kate"], "developer_validation": "verified",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/10/kate.svg.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/10/kate.svg.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/kate.png"}],
+        "origin": "kde", "package_name": "kate", "publisher": "KDE", "sections": [],
+        "summary": "KDE Advanced Text Editor", "title": "kate"}, {"apps": [], "developer_validation":
+        "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/snapd.png",
+        "media": [{"height": 460, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/snapd.png",
+        "width": 460}, {"height": 648, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/Screenshot_20190924_115756_hLcyetO.png",
+        "width": 956}, {"height": 648, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/Screenshot_20190924_115824_2v3y6l8.png",
+        "width": 956}, {"height": 834, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/Screenshot_20190924_115055_Uuq7KIb.png",
+        "width": 1023}, {"height": 648, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/Screenshot_20190924_125944.png",
+        "width": 956}], "origin": "canonical", "package_name": "snapd", "publisher":
+        "Canonical", "sections": [], "summary": "Background service that manages and
+        maintains installed snaps", "title": "snapd"}, {"apps": ["iwspy", "iwconfig",
+        "rfkill", "iwgetid", "iwpriv", "iw", "iwevent"], "developer_validation": "verified",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/icon_19.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/icon_19.png"}],
+        "origin": "canonical", "package_name": "wireless-tools", "publisher": "Canonical",
+        "sections": [], "summary": "Tools for manipulating Linux Wireless Extensions",
+        "title": "wireless-tools"}, {"apps": ["goland"], "developer_validation": "verified",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/go_1282x.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/go_1282x.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/go_overview.png"}],
+        "origin": "jetbrains", "package_name": "goland", "publisher": "jetbrains",
+        "sections": [{"featured": false, "name": "development"}], "summary": "A Clever
+        IDE to Go", "title": "GoLand"}, {"apps": ["space"], "developer_validation":
+        "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/ezgif.com-gif-maker.png",
+        "media": [{"height": 512, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/ezgif.com-gif-maker.png",
+        "width": 512}, {"height": 1860, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/home_for_teams.png",
+        "width": 2880}, {"height": 1638, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/collaborate_on_code_in_place.png",
+        "width": 2880}, {"height": 1736, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/issue_tracking.png",
+        "width": 2880}], "origin": "jetbrains", "package_name": "space", "publisher":
+        "jetbrains", "sections": [{"featured": false, "name": "development"}], "summary":
+        "Desktop Application for JetBrains Space", "title": "Space"}, {"apps": ["irccloud"],
+        "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/icon_fvVGr52.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/icon_fvVGr52.png"},
+        {"height": 1296, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/4a4675a8-7246-46b6-9d64-183a990b49f9.png",
+        "width": 2340}, {"height": 1296, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/e6ffefaa-8ecc-402f-8037-1b72112b43aa.png",
+        "width": 2340}, {"height": 1296, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/e2d56fdb-1c99-4099-9e5a-5af17cc5885b.png",
+        "width": 2340}], "origin": "irccloud", "package_name": "irccloud", "publisher":
+        "IRCCloud", "sections": [{"featured": false, "name": "productivity"}, {"featured":
+        false, "name": "social"}], "summary": "An IRC client with a future. Stay connected,
+        chat from anywhere, and never miss a message", "title": "IRCCloud"}, {"apps":
+        ["dotnet"], "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/msft.net_256_8NLBkoS.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/msft.net_256_8NLBkoS.png"}],
+        "origin": "dotnetcore", "package_name": "dotnet-sdk", "publisher": "Microsoft
+        .NET Core", "sections": [{"featured": false, "name": "development"}], "summary":
+        "Develop high performance applications in less time, on any platform.", "title":
+        ".NET Core SDK"}, {"apps": ["qmi-network", "qmicli", "mbim-network", "mbimcli",
+        "mmcli"], "developer_validation": "verified", "icon_url": "", "media": [],
+        "origin": "canonical", "package_name": "modem-manager", "publisher": "Canonical",
+        "sections": [{"featured": false, "name": "devices-and-iot"}], "summary": "ModemManager
+        is a service which controls mobile broadband", "title": "modem-manager"},
+        {"apps": [], "developer_validation": "verified", "icon_url": "", "media":
+        [], "origin": "canonical", "package_name": "ofono", "publisher": "Canonical",
+        "sections": [], "summary": "Mobile telephony daemon", "title": "ofono"}, {"apps":
+        ["shyaml", "snap-revision", "bugsurfer", "setup-snap-repo", "flightschedule"],
+        "developer_validation": "verified", "icon_url": "", "media": [], "origin":
+        "canonical", "package_name": "se-dev-tools", "publisher": "Canonical", "sections":
+        [], "summary": "A set of utilities that help make working with our team snaps
+        easier", "title": "se-dev-tools"}, {"apps": [], "developer_validation": "verified",
+        "icon_url": "", "media": [], "origin": "canonical", "package_name": "gucharmap-udt",
+        "publisher": "Canonical", "sections": [], "summary": "Unicode character picker
+        and font browser", "title": "gucharmap-udt"}, {"apps": ["simple-obex-agent"],
+        "developer_validation": "verified", "icon_url": "", "media": [], "origin":
+        "canonical", "package_name": "bluez-tests", "publisher": "Canonical", "sections":
+        [], "summary": "Set of utilities that are not production ready yet help in
+        testing", "title": "bluez-tests"}, {"apps": ["alsa-utils", "udisks2", "run",
+        "plainbox", "tpm", "pulseaudio", "network-manager", "bluez", "wifi-ap", "upower",
+        "modem-manager", "media-hub", "wireless-tools"], "developer_validation": "verified",
+        "icon_url": "", "media": [], "origin": "canonical", "package_name": "canonical-se-engineering-tests",
+        "publisher": "Canonical", "sections": [], "summary": "Canonical System Enablement
+        Engineering Test cases", "title": "canonical-se-engineering-tests"}, {"apps":
+        ["qr-code-generator-desktop"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/icon_P7afCqs.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/icon_P7afCqs.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/screenshot-1_sjeP5p2.png"}],
+        "origin": "studiolacosanostra", "package_name": "qr-code-generator-desktop",
+        "publisher": "Studio La Cosa Nostra", "sections": [{"featured": false, "name":
+        "utilities"}], "summary": "Create custom QR Codes. You can save them as PNG
+        image. You can change the size of the image.", "title": "QR Code Generator"},
+        {"apps": ["codenamelt"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/icon_256x256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/icon_256x256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/screenshot_snap.png"}],
+        "origin": "eri0o", "package_name": "codenamelt", "publisher": "erico_pt",
+        "sections": [{"featured": false, "name": "games"}], "summary": "A pixelart
+        game where you have to run without getting caught by evil agents.", "title":
+        "codenamelt"}, {"apps": ["codedoc"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/codedoc-256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/codedoc-256.png"}],
+        "origin": "michaelrsweet", "package_name": "codedoc", "publisher": "Michael
+        Sweet", "sections": [{"featured": false, "name": "utilities"}], "summary":
+        "Code documentation utility.", "title": "codedoc"}, {"apps": ["ampareqrcodelinux"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/qr-code.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/qr-code.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/Screenshot_2018-02-11_01-50-38.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/Screenshot_2018-02-11_01-50-30.png"}],
+        "origin": "juthawong", "package_name": "ampareqrcodelinux", "publisher": "Juthawong
+        Naisanguansee", "sections": [], "summary": "Create Your Own QR Code From Any
+        Text and Save", "title": "Ampare QR Code Creator"}, {"apps": ["prettier"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/prettier-icon-dark.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/prettier-icon-dark.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/screenshot_nFeUCLQ.png"}],
+        "origin": "sangbum", "package_name": "prettier", "publisher": "Sangbum Kim",
+        "sections": [], "summary": "Prettier is an opinionated code formatter", "title":
+        "prettier"}, {"apps": ["scc"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/icon_PvPKbUH.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/icon_PvPKbUH.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/screenshot_bwlDNiR.png"}],
+        "origin": "felicianotech", "package_name": "scc", "publisher": "Ricardo N
+        Feliciano", "sections": [{"featured": false, "name": "development"}], "summary":
+        "scc is a very fast & accurate code counter counting lines of code by language.",
+        "title": "scc"}, {"apps": ["line-calc"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/03/icon_7.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/03/icon_7.png"}],
+        "origin": "quasarapp", "package_name": "line-calc", "publisher": "Andrei Yancovich",
+        "sections": [], "summary": "Utility for counting the number of lines in a
+        project.", "title": "Line Calc"}, {"apps": ["gisto"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/icon_60sKxPN.png",
+        "media": [{"height": 512, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/icon_60sKxPN.png",
+        "width": 512}, {"height": 1600, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/Jx8Tc9s.png",
+        "width": 2560}, {"height": 1600, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/yiEJRNt.png",
+        "width": 2560}, {"height": 1600, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/JtUCsfI.png",
+        "width": 2560}, {"height": 1600, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/Aac48m9.png",
+        "width": 2560}, {"height": 1600, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/bXySAUt.png",
+        "width": 2560}], "origin": "gisto", "package_name": "gisto", "publisher":
+        "Gisto", "sections": [{"featured": false, "name": "development"}, {"featured":
+        false, "name": "productivity"}], "summary": "Code snippet manager, runs on
+        GitHub Gists and adds additional features such as searching, tagging gists
+        with rich code editor.", "title": "Gisto"}, {"apps": ["amparetraceroute"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/04/trace.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/04/trace.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/04/Screenshot_2018-04-19_18-14-20.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/04/Screenshot_2018-04-19_18-13-28.png"}],
+        "origin": "juthawong", "package_name": "amparetraceroute", "publisher": "Juthawong
+        Naisanguansee", "sections": [], "summary": "Trace HTTP Route and Display Result",
+        "title": "Ampare HTTP Trace Route"}, {"apps": ["broker"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/apibillme_copy_tdEZI5g.png",
+        "media": [{"height": 256, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/apibillme_copy_tdEZI5g.png",
+        "width": 256}, {"height": 500, "type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/1500x500.jpeg",
+        "width": 1500}], "origin": "bevanhunt", "package_name": "broker", "publisher":
+        "Bevan Hunt", "sections": [{"featured": false, "name": "server-and-cloud"}],
+        "summary": "Real-time Zero-Code API Server", "title": "broker"}, {"apps":
+        ["cppcheck"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/cppcheck.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/cppcheck.png"}],
+        "origin": "cking-kernel-tools", "package_name": "cppcheck", "publisher": "Colin
+        King", "sections": [{"featured": false, "name": "development"}], "summary":
+        "A tool for static C/C++ code analysis", "title": "cppcheck"}, {"apps": ["zig"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/zig-icon.svg.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/zig-icon.svg.png"}],
+        "origin": "jayschwa", "package_name": "zig", "publisher": "Jay Petacat", "sections":
+        [{"featured": false, "name": "development"}], "summary": "Zig Programming
+        Language", "title": "Zig"}, {"apps": ["packer"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/04/packer-abacao.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/04/packer-abacao.png"}],
+        "origin": "abacao", "package_name": "packer-abacao", "publisher": "Andr\u00e9
+        Ba\u00e7\u00e3o", "sections": [], "summary": "Packer - Build Automated Machine
+        Images", "title": "packer-abacao"}, {"apps": ["cppcheckgui"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/cppcheck-gui.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/cppcheck-gui.png"}],
+        "origin": "gocarlos", "package_name": "cppcheckgui", "publisher": "Carlos
+        Gomes Martinho", "sections": [], "summary": "A tool for static C/C++ code
+        analysis", "title": "cppcheckgui"}, {"apps": ["rdplot"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/PLOT256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/PLOT256.png"}],
+        "origin": "schneider-p", "package_name": "rdplot", "publisher": "Jens Schneider",
+        "sections": [], "summary": "The plotting tool for rate distortion curves in
+        the context of video coding.", "title": "rdplot"}, {"apps": ["amparecssrandomcolor"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/icon_qBUklKz.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/icon_qBUklKz.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/Screenshot_from_2018-09-04_22-29-53.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/Screenshot_from_2018-09-04_22-29-36.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/Screenshot_from_2018-09-04_22-28-59.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/Screenshot_from_2018-09-04_22-28-46.png"}],
+        "origin": "juthawong", "package_name": "amparecssrandomcolor", "publisher":
+        "Juthawong Naisanguansee", "sections": [], "summary": "Random Color with CSS
+        Hexadecimal Code For Next Web Design Idea", "title": "Ampare Random CSS Color"},
+        {"apps": ["puppetry"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/puppetry-256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/puppetry-256.png"},
+        {"height": 400, "type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/main-1x3.png",
+        "width": 1200}, {"height": 720, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/main_VoewqIW.png",
+        "width": 1200}, {"height": 720, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/article-relative-position.png",
+        "width": 1200}, {"height": 720, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/article-report-ok.png",
+        "width": 1200}, {"height": 720, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/article-css-regression.png",
+        "width": 1200}], "origin": "dsheiko", "package_name": "puppetry", "publisher":
+        "Dzmitry Sheiko", "sections": [{"featured": false, "name": "development"},
+        {"featured": false, "name": "utilities"}], "summary": "Puppetry - codeless
+        end-to-end test automation, integrated with CI/CD pipeline", "title": "Puppetry"},
+        {"apps": ["python-vvv", "report", "python-add-root", "python", "report-add-root",
+        "python-v", "pynsource", "python-add-site", "report-add-site"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/G12-Folder-Doc-icon.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/G12-Folder-Doc-icon.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/pynsource-mbp-screen-python.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/pynsource-zoom-line-edit.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/pynsource-ascii_uml.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/2019-03-02_12-15-04-1.gif"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/pynsource-plantuml-2.png"}],
+        "origin": "andybulka", "package_name": "pynsource", "publisher": "Andy", "sections":
+        [{"featured": false, "name": "development"}], "summary": "Pynsource - reverse
+        engineer Python source code into UML", "title": "Pynsource - UML tool for
+        Python"}, {"apps": ["qxmledit"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/qxmledit.svg.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/qxmledit.svg.png"},
+        {"type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/QXmlEdit_Banner_Snap_Store.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/qxmledit-screenshot-800.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/anonymize.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/attribute_filter.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/base64.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/charinfo.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/codepages.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/comparexsd.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/editelement.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/encodings.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/heatmaps.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/relations.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/split.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/structure.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/xsd.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/xslt.png"}],
+        "origin": "frederickjh", "package_name": "qxmledit", "publisher": "Frederick
+        J. Henderson", "sections": [{"featured": false, "name": "development"}, {"featured":
+        false, "name": "utilities"}], "summary": "QXmlEdit is a simple XML editor
+        based on Qt libraries.", "title": "qxmledit"}, {"apps": ["rockscissorspaperlizardspock-snap"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/rockscissorspaperlizardspock-snap.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/rockscissorspaperlizardspock-snap.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/RSPLS-snap_screenshot1.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/RSPLS-snap_screenshot2.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/RSPLS-snap_screenshot3.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/RSPLS-snap_screenshot4.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/RSPLS-snap_screenshot5.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/RSPLS-snap_screenshot6.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/RSPLS-snap_screenshot7.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/RSPLS-snap_screenshot8.png"}],
+        "origin": "phelion", "package_name": "rockscissorspaperlizardspock-snap",
+        "publisher": "pHeLiOn", "sections": [], "summary": "2 player game of a variation
+        of ''Rock, Paper, Scissors''", "title": "rockscissorspaperlizardspock-snap"},
+        {"apps": ["e-tools"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/512.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/512.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/v1.3.6.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/english.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/chinese.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/russian.png"}],
+        "origin": "suremotoo", "package_name": "e-tools", "publisher": "Suremotoo",
+        "sections": [{"featured": false, "name": "development"}], "summary": "A toolbox
+        for developers. Color picker, code formatter, and more", "title": "E-tools"},
+        {"apps": ["gif2flif", "flif", "dflif", "viewflif", "apng2flif"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/index.png",
+        "media": [{"height": 512, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/index.png",
+        "width": 512}], "origin": "nevermine17", "package_name": "flif", "publisher":
+        "Danil Nikolaev", "sections": [{"featured": false, "name": "photo-and-video"},
+        {"featured": false, "name": "utilities"}], "summary": "All the tools you need
+        for the Free Lossless Image Format", "title": "FLIF - Free Lossless Image
+        Format"}, {"apps": ["authenticator"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/icon_6nLCgqR.png",
+        "media": [{"height": 128, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/icon_6nLCgqR.png",
+        "width": 128}], "origin": "jocave", "package_name": "authenticator-joc", "publisher":
+        "Jonathan Cave", "sections": [{"featured": false, "name": "security"}], "summary":
+        "A Two-Factor Authentication application", "title": "authenticator-joc"},
+        {"apps": ["daemon-testnet", "daemon", "cli-regtest", "cli", "tx", "qt-testnet",
+        "daemon-regtest", "cli-testnet", "qt-regtest", "qt"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/ion256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/ion256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/splash.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/multisig-overview.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/blockexplorer.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/commandline-options.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/options.png"}],
+        "origin": "ioncoin", "package_name": "ioncore", "publisher": "Ion coin developer",
+        "sections": [{"featured": false, "name": "finance"}, {"featured": false, "name":
+        "games"}], "summary": "gaming related peer-to-peer network based digital currency",
+        "title": "Ion Digital Currency (Official release)"}, {"apps": ["brackets"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/brackets.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/brackets.png"}],
+        "origin": "cprov", "package_name": "cprov-brackets", "publisher": "Celso Providelo",
+        "sections": [], "summary": "Brackets is a modern code editor for HTML, CSS
+        and JavaScript.", "title": "cprov-brackets"}, {"apps": ["hub"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/icon.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/icon.png"}],
+        "origin": "felicianotech", "package_name": "hub", "publisher": "Ricardo N
+        Feliciano", "sections": [{"featured": false, "name": "development"}], "summary":
+        "hub is a command-line wrapper for git that makes you better at GitHub.",
+        "title": "hub"}, {"apps": ["vokoscreen-ng"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/vokoscreen-ng.png",
+        "media": [{"height": 256, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/vokoscreen-ng.png",
+        "width": 256}, {"height": 483, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/02/Screenshot_from_2020-02-06_08-53-40.png",
+        "width": 730}, {"height": 483, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/02/Screenshot_from_2020-02-06_08-54-09.png",
+        "width": 730}, {"height": 483, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/02/Screenshot_from_2020-02-06_08-54-35.png",
+        "width": 730}], "origin": "popey", "package_name": "vokoscreen-ng", "publisher":
+        "Alan Pope", "sections": [{"featured": false, "name": "photo-and-video"},
+        {"featured": false, "name": "utilities"}], "summary": "vokoscreenNG", "title":
+        "vokoscreenNG"}, {"apps": ["color-picker"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/app.png",
+        "media": [{"height": 512, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/app.png",
+        "width": 512}, {"height": 708, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/pic_1.png",
+        "width": 530}, {"height": 705, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/pic_2.png",
+        "width": 929}], "origin": "keshavnrj", "package_name": "color-picker", "publisher":
+        "keshavbhatt", "sections": [{"featured": false, "name": "development"}, {"featured":
+        false, "name": "utilities"}], "summary": "A colour picker and colour editor
+        for web designers and digital artists", "title": "Color Picker"}, {"apps":
+        ["azimuth"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/azimuth480.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/azimuth480.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/Screenshot_20190412_214356.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/Screenshot_20190412_214437.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/Screenshot_20190412_214544.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/Screenshot_20190412_214704-1.png"}],
+        "origin": "popey", "package_name": "azimuth", "publisher": "Alan Pope", "sections":
+        [{"featured": false, "name": "games"}], "summary": "Azimuth - A metroidvania
+        with vector graphics", "title": "azimuth"}, {"apps": [], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/icon256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/icon256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/osddm.png"}],
+        "origin": "vs", "package_name": "osddm", "publisher": "vasilisc", "sections":
+        [{"featured": false, "name": "development"}], "summary": "Oracle SQL Developer
+        Data Modeler", "title": "osddm"}, {"apps": ["barriers", "barrierc", "barrier"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/08/icon.svg_JtFjzqW.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/08/icon.svg_JtFjzqW.png"}],
+        "origin": "adrianceleste", "package_name": "barrier", "publisher": "Adrian
+        Lucr\u00e8ce C\u00e9leste", "sections": [{"featured": false, "name": "productivity"}],
+        "summary": "Barrier - Share mouse and keyboard over the local network", "title":
+        "barrier"}, {"apps": ["sectrain"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/st-snapico.png",
+        "media": [{"height": 493, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/st-snapico.png",
+        "width": 493}, {"height": 500, "type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/st-banner.png",
+        "width": 1500}, {"height": 974, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/st-xss.png",
+        "width": 1804}, {"height": 974, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/st-home.png",
+        "width": 1804}, {"height": 974, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/st-install.png",
+        "width": 1804}, {"height": 974, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/st-py.png",
+        "width": 1804}], "origin": "joemcmanus", "package_name": "sectrain", "publisher":
+        "Joe McManus", "sections": [{"featured": false, "name": "education"}, {"featured":
+        false, "name": "security"}], "summary": "A training tool displaying some techniques
+        for secure web app development", "title": "sectrain"}, {"apps": ["yquake2",
+        "yquake2-launch"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/quake2.svg.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/quake2.svg.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/Bildschirmfoto_von_2018-08-25_17-09-46.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/Bildschirmfoto_von_2018-08-25_17-10-11.png"}],
+        "origin": "beidl", "package_name": "yamagi-quake2-beidl", "publisher": "Alfred
+        E. Neumayer", "sections": [], "summary": "An enhanced version of id Software''s
+        Quake II.", "title": "Yamagi Quake II"}, {"apps": ["kimitzu-client"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/icon_vwLGEQ1.png",
+        "media": [{"height": 512, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/icon_vwLGEQ1.png",
+        "width": 512}, {"height": 660, "type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/full-blue.png",
+        "width": 1980}, {"height": 1080, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/Screenshot_from_2020-01-22_09-53-27.png",
+        "width": 1920}, {"height": 1080, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/Screenshot_from_2020-01-22_12-38-04.png",
+        "width": 1920}], "origin": "kimitzu", "package_name": "kimitzu-client", "publisher":
+        "Kimitzu Foundation", "sections": [{"featured": false, "name": "utilities"}],
+        "summary": "Kimitzu Client: A free market for services", "title": "Kimitzu"},
+        {"apps": ["bussard"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/03/bussard_256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/03/bussard_256.png"}],
+        "origin": "popey", "package_name": "bussard", "publisher": "Alan Pope", "sections":
+        [], "summary": "Bussard", "title": "bussard"}, {"apps": ["gamecake", "grd",
+        "jam", "midi"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/09/gamecake.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/09/gamecake.png"},
+        {"height": 640, "type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/gcake.png",
+        "width": 1920}, {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/09/20170811_134606.png"},
+        {"height": 485, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/screen_2McWHe5.png",
+        "width": 648}, {"height": 512, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/screen_qhfNjQZ.png",
+        "width": 911}, {"height": 744, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/screen_6b6P2KQ.png",
+        "width": 1349}, {"height": 1056, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/screen_qlUaH1Y.png",
+        "width": 1920}], "origin": "xriss", "package_name": "gamecake", "publisher":
+        "kriss", "sections": [{"featured": false, "name": "development"}, {"featured":
+        false, "name": "games"}], "summary": "a single exe cross platform Lua game
+        engine", "title": "gamecake"}, {"apps": ["epictask"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/icon-256x256.png",
+        "media": [{"type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/epictask-banner.png"},
+        {"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/icon-256x256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/epictask-screen-01.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/epictask-screen-02.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/epictask-screen-03.png"}],
+        "origin": "densebrain", "package_name": "epictask", "publisher": "Densebrain,
+        Inc", "sections": [{"featured": false, "name": "development"}, {"featured":
+        false, "name": "utilities"}], "summary": "*Github* issues are your bitch!",
+        "title": "Epictask"}, {"apps": ["dspatcher"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/heartbeat.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/heartbeat.png"},
+        {"height": 723, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/08/DSPatcher_-_Screenshot.png",
+        "width": 1161}], "origin": "marcustomlinson", "package_name": "dspatcher",
+        "publisher": "Marcus Tomlinson", "sections": [{"featured": false, "name":
+        "music-and-audio"}, {"featured": false, "name": "science"}], "summary": "Cross-Platform
+        Graphical Tool for DSPatch", "title": "dspatcher"}]}, "_links": {"last": {"href":
+        "https://api.snapcraft.io/api/v1/snaps/search?q=code&size=100&page=3&scope=wide&confinement=strict%2Cclassic&fields=package_name%2Ctitle%2Csummary%2Cicon_url%2Cmedia%2Cpublisher%2Cdeveloper_validation%2Corigin%2Capps%2Csections&arch=wide"},
+        "next": {"href": "https://api.snapcraft.io/api/v1/snaps/search?q=code&size=100&page=2&scope=wide&confinement=strict%2Cclassic&fields=package_name%2Ctitle%2Csummary%2Cicon_url%2Cmedia%2Cpublisher%2Cdeveloper_validation%2Corigin%2Capps%2Csections&arch=wide"},
+        "self": {"href": "https://api.snapcraft.io/api/v1/snaps/search?q=code&size=100&page=1&scope=wide&confinement=strict%2Cclassic&fields=package_name%2Ctitle%2Csummary%2Cicon_url%2Cmedia%2Cpublisher%2Cdeveloper_validation%2Corigin%2Capps%2Csections&arch=wide"}},
+        "total": 287}'
+    headers:
+      Age:
+      - '584'
+      Content-Length:
+      - '73481'
+      Content-Type:
+      - application/hal+json
+      Date:
+      - Wed, 19 Feb 2020 13:11:02 GMT
+      Server:
+      - gunicorn/19.7.1
+      Snap-Store-Version:
+      - '18'
+      Vary:
+      - X-Ubuntu-Store, X-Ubuntu-Series, X-Ubuntu-Architecture
+      Via:
+      - 1.1 juju-7794b8-prod-ols-snap-store-indep-1656 (squid/3.5.27)
+      X-Cache:
+      - HIT from juju-7794b8-prod-ols-snap-store-indep-1656
+      X-Cache-Lookup:
+      - HIT from juju-7794b8-prod-ols-snap-store-indep-1656:3128
+      X-Request-Id:
+      - 59C57682A9EE0A325C7F01BB5E4D33E436C5BF7
+      X-VCS-Revision:
+      - 3476d7a
+      X-View-Name:
+      - snapdevicegw.webapi_search.snap_search
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+      X-Ubuntu-Architecture:
+      - wide
+      X-Ubuntu-Series:
+      - '16'
+    method: GET
+    uri: https://api.snapcraft.io/api/v1/snaps/search?q=code&size=300&page=1&scope=wide&confinement=strict%2Cclassic&fields=package_name%2Ctitle%2Csummary%2Cicon_url%2Cmedia%2Cpublisher%2Cdeveloper_validation%2Corigin%2Capps%2Csections&arch=wide
+  response:
+    body:
+      string: '{"_embedded": {"clickindex:package": [{"apps": ["code", "url-handler"],
+        "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/code_ozwVHSV.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/code_ozwVHSV.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/09/home-screenshot-linux.png"}],
+        "origin": "vscode", "package_name": "code", "publisher": "Visual Studio Code",
+        "sections": [{"featured": false, "name": "development"}], "summary": "Code
+        editing. Redefined.", "title": "Visual Studio Code"}, {"apps": ["subl"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/03/sublime-text.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/03/sublime-text.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/03/linux.png"}],
+        "origin": "snapcrafters", "package_name": "sublime-text", "publisher": "Snapcrafters",
+        "sections": [{"featured": true, "name": "development"}], "summary": "A sophisticated
+        text editor for code, markup and prose.", "title": "Sublime Text"}, {"apps":
+        ["pycharm-community"], "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/PyCharmCore256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/PyCharmCore256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/pycharm_com_general.png"}],
+        "origin": "jetbrains", "package_name": "pycharm-community", "publisher": "jetbrains",
+        "sections": [{"featured": true, "name": "development"}], "summary": "Python
+        IDE for Professional Developers", "title": "PyCharm CE"}, {"apps": ["android-studio"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/03/rsz_android_studio_icon.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/03/rsz_android_studio_icon.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/03/android-studio.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/Screenshot_20190418_002828.png"}],
+        "origin": "snapcrafters", "package_name": "android-studio", "publisher": "Snapcrafters",
+        "sections": [{"featured": true, "name": "development"}, {"featured": true,
+        "name": "featured"}], "summary": "The IDE for Android", "title": "Android
+        Studio"}, {"apps": ["riot-web"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/icon_Jfu5bEq.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/icon_Jfu5bEq.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/Screenshot_from_2019-05-29_22-37-35.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/home-communication.png"}],
+        "origin": "popey", "package_name": "riot-web", "publisher": "Alan Pope", "sections":
+        [{"featured": true, "name": "featured"}], "summary": "Communicate the way
+        you want with Riot", "title": "Riot"}, {"apps": ["npm", "desktop-launch"],
+        "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/nr-hex_1.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/nr-hex_1.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/knol.png"}],
+        "origin": "noderedteam", "package_name": "node-red", "publisher": "Node-RED-Team",
+        "sections": [{"featured": false, "name": "development"}, {"featured": true,
+        "name": "devices-and-iot"}], "summary": "Low-code programming for event-driven
+        applications", "title": "Node-RED"}, {"apps": ["docker", "machine", "compose",
+        "help"], "developer_validation": "verified", "icon_url": "", "media": [],
+        "origin": "canonical", "package_name": "docker", "publisher": "Canonical",
+        "sections": [{"featured": true, "name": "server-and-cloud"}], "summary": "Docker
+        container runtime", "title": "Docker"}, {"apps": ["mindustry"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/mindustry.png",
+        "media": [{"height": 256, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/mindustry.png",
+        "width": 256}, {"height": 1053, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/Screenshot_from_2019-09-22_19-06-24.png",
+        "width": 1920}, {"height": 1167, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/zLgp0A.png",
+        "width": 1905}, {"height": 836, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/wT1_AW.png",
+        "width": 1140}], "origin": "popey", "package_name": "mindustry", "publisher":
+        "Alan Pope", "sections": [{"featured": true, "name": "featured"}, {"featured":
+        false, "name": "games"}], "summary": "A sandbox tower defense game", "title":
+        "Mindustry"}, {"apps": ["bitwarden"], "developer_validation": "verified",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/256x256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/256x256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/04/bitwarden_ubuntu.PNG"}],
+        "origin": "bitwarden", "package_name": "bitwarden", "publisher": "8bit Solutions
+        LLC", "sections": [{"featured": false, "name": "productivity"}, {"featured":
+        true, "name": "security"}, {"featured": false, "name": "utilities"}], "summary":
+        "A secure and free password manager for all of your devices.", "title": "Bitwarden"},
+        {"apps": ["notepad-plus-plus"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/notepad-plus-plus.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/notepad-plus-plus.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/04/screenshot.png"}],
+        "origin": "mmtrt", "package_name": "notepad-plus-plus", "publisher": "Taqi
+        Raza", "sections": [{"featured": true, "name": "development"}], "summary":
+        "Notepad-Plus-Plus is a free source code editor.", "title": "Notepad-Plus-Plus
+        (WINE)"}, {"apps": ["cli", "ghb"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2016/10/handbrake-jz.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/10/handbrake-jz.png"}],
+        "origin": "jz", "package_name": "handbrake-jz", "publisher": "Jacob Zimmermann",
+        "sections": [{"featured": true, "name": "photo-and-video"}], "summary": "The
+        open source video transcoder", "title": "handbrake-jz"}, {"apps": ["gnome-calculator"],
+        "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/07/accessories-calculator.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/07/accessories-calculator.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/07/Screenshot_from_2017-07-19_15-23-11.png"}],
+        "origin": "canonical", "package_name": "gnome-calculator", "publisher": "Canonical",
+        "sections": [{"featured": true, "name": "finance"}, {"featured": false, "name":
+        "utilities"}], "summary": "GNOME Calculator", "title": "GNOME Calculator"},
+        {"apps": ["initcaddy", "restoredb", "backupdb", "mongo"], "developer_validation":
+        "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/icon-256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/icon-256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/Screen_Shot_2016-02-22_at_21.44.26.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/Screen_Shot_2016-02-22_at_21.45.00.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/Screen_Shot_2016-02-22_at_21.45.35.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/Screen_Shot_2016-02-22_at_21.47.10.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/Screen_Shot_2016-02-22_at_21.48.31.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/Screen_Shot_2016-03-09_at_20.15.01.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/Screen_Shot_2016-03-18_at_18.00.07.png"}],
+        "origin": "rocketchat", "package_name": "rocketchat-server", "publisher":
+        "Rocket.Chat", "sections": [{"featured": true, "name": "server-and-cloud"}],
+        "summary": "Group chat server for 100s,  installed in seconds.", "title":
+        "Rocket.Chat Server"}, {"apps": ["intellij-idea-community"], "developer_validation":
+        "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/icon_CE_256_2Qe5uEl.png",
+        "media": [{"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/09/screenshot_Pm7mWCg.png"},
+        {"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/icon_CE_256_2Qe5uEl.png"}],
+        "origin": "jetbrains", "package_name": "intellij-idea-community", "publisher":
+        "jetbrains", "sections": [{"featured": true, "name": "development"}], "summary":
+        "Capable & Ergonomic Java IDE", "title": "IDEA Community"}, {"apps": ["phpstorm"],
+        "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/webide.ico_HA9tBL0.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/webide.ico_HA9tBL0.png"},
+        {"height": 980, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/08/welcome.png",
+        "width": 1554}, {"height": 2105, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/08/overview.png",
+        "width": 3706}], "origin": "jetbrains", "package_name": "phpstorm", "publisher":
+        "jetbrains", "sections": [{"featured": true, "name": "development"}], "summary":
+        "PHP IDE for Professional Development", "title": "PhpStorm"}, {"apps": ["wormhole"],
+        "developer_validation": "unproven", "icon_url": "", "media": [{"type": "screenshot",
+        "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/07/Screenshot_from_2018-07-02_14-23-15.png"}],
+        "origin": "snapcrafters", "package_name": "wormhole", "publisher": "Snapcrafters",
+        "sections": [{"featured": true, "name": "utilities"}], "summary": "get things
+        from one computer to another, safely", "title": "wormhole"}, {"apps": ["copay"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/256x256_6ileytI.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/256x256_6ileytI.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/linux-image-copay1_LrjSusR.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/linux-image-copay2_2PODIzz.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/linux-image-copay3_ugITmgN.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/linux-image-copay4_A0dvFl0.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/linux-image-copay5_4zbhWlR.png"}],
+        "origin": "gabrielbitpay", "package_name": "copay", "publisher": "BitPay",
+        "sections": [{"featured": true, "name": "finance"}], "summary": "A Secure
+        Bitcoin Wallet", "title": "Copay"}, {"apps": ["ebook2cw"], "developer_validation":
+        "unproven", "icon_url": "", "media": [], "origin": "bh1scw", "package_name":
+        "ebook2cw", "publisher": "FJKong", "sections": [{"featured": true, "name":
+        "books-and-reference"}], "summary": "ebook2cw - convert ebooks to Morse MP3s/OGGs",
+        "title": "ebook2cw"}, {"apps": ["gitkraken"], "developer_validation": "verified",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/1.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/1.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/pull-requests_1oUC7KR.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/banner_wDoKy9V.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/banner-icon_vWkDBG3.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/graph.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/merge-conflict.png"}],
+        "origin": "gitkraken", "package_name": "gitkraken", "publisher": "gitkraken",
+        "sections": [{"featured": true, "name": "development"}], "summary": "For repo
+        management, in-app code editing & issue tracking.", "title": "GitKraken"},
+        {"apps": ["bitpay"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/256x256_6u0RIUd.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/256x256_6u0RIUd.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/linux-image-bitpay1.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/linux-image-bitpay2.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/linux-image-bitpay3.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/linux-image-bitpay4.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/linux-image-bitpay5.png"}],
+        "origin": "gabrielbitpay", "package_name": "bitpay", "publisher": "BitPay",
+        "sections": [{"featured": true, "name": "finance"}], "summary": "A Secure
+        Bitcoin Wallet", "title": "BitPay"}, {"apps": ["config-merge", "mirror", "update-source",
+        "groups", "help", "deploy", "java", "indexer", "sync", "projadm", "opengrok",
+        "reindex-project"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/03/icon.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/03/icon.png"}],
+        "origin": "ondra", "package_name": "opengrok", "publisher": "Ondrej Kubik",
+        "sections": [{"featured": true, "name": "books-and-reference"}], "summary":
+        "OpenGrok is a fast and usable source code search and cross reference engine,
+        written in Java", "title": "{OpenGrok"}, {"apps": ["notepadqq"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/icon.svg_7Eenexu.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/icon.svg_7Eenexu.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/screen_edited.png"}],
+        "origin": "danieleds", "package_name": "notepadqq", "publisher": "Daniele
+        Di Sarli", "sections": [{"featured": true, "name": "development"}, {"featured":
+        false, "name": "productivity"}], "summary": "A Notepad++-like editor for Linux.",
+        "title": "notepadqq"}, {"apps": [], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2016/05/icon_7.png", "media":
+        [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/05/icon_7.png"}],
+        "origin": "elopio", "package_name": "keepassx-elopio", "publisher": "Leo Arias",
+        "sections": [{"featured": true, "name": "security"}], "summary": "KeePassX
+        is a cross platform password safe", "title": "keepassx-elopio"}, {"apps":
+        ["mjpg-streamer"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/webcam.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/webcam.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/streamer.png"}],
+        "origin": "ogra", "package_name": "mjpg-streamer", "publisher": "Oliver Grawert",
+        "sections": [{"featured": true, "name": "photo-and-video"}], "summary": "UVC
+        webcam streaming tool", "title": "mjpg-streamer"}, {"apps": ["intellij-idea-ultimate"],
+        "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/10/logo_zjwX5FR.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/10/logo_zjwX5FR.png"},
+        {"height": 705, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/08/idea_overview_2_copy.png",
+        "width": 1008}], "origin": "jetbrains", "package_name": "intellij-idea-ultimate",
+        "publisher": "jetbrains", "sections": [{"featured": true, "name": "development"}],
+        "summary": "Capable & Ergonomic Java IDE for Enterprise, Web & Mobile Development",
+        "title": "IDEA Ultimate"}, {"apps": ["cacher"], "developer_validation": "verified",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/ubuntu-login.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/ubuntu-login.png"},
+        {"height": 640, "type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/10/snapcraft_bg.png",
+        "width": 1920}, {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/cacher-demo.gif"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/full-featured.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/labels.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/editors.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/teams.png"}],
+        "origin": "cacherapp", "package_name": "cacher", "publisher": "Penguin Labs,
+        LLC", "sections": [{"featured": true, "name": "development"}], "summary":
+        "Cacher is a code snippet library for professional developers. Use it to build
+        a technical knowledge base for you and your team.", "title": "Cacher"}, {"apps":
+        ["mpv"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/08/mpv.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/08/mpv.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/08/Selection_008_LKgCxuk.png"}],
+        "origin": "casept", "package_name": "mpv", "publisher": "David Paskevic",
+        "sections": [{"featured": true, "name": "photo-and-video"}], "summary": "a
+        free, open source, and cross-platform media player.", "title": "mpv"}, {"apps":
+        ["webstorm"], "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/WebStorm_1282x.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/WebStorm_1282x.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/webstorm-on-linux.png"}],
+        "origin": "jetbrains", "package_name": "webstorm", "publisher": "jetbrains",
+        "sections": [{"featured": true, "name": "development"}], "summary": "Powerful
+        IDE for modern JavaScript development", "title": "WebStorm"}, {"apps": ["codebreakers"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/codebreakers.png",
+        "media": [{"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/ScreenShot2.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/Screenshot3.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/Screenshot1.png"},
+        {"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/codebreakers.png"}],
+        "origin": "vagueentertainment", "package_name": "codebreakers", "publisher":
+        "Vague Entertainment", "sections": [{"featured": true, "name": "games"}],
+        "summary": "Guess the code and unlock RogueBot Central", "title": "codebreakers"},
+        {"apps": ["brackets"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/07/brackets_256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/07/brackets_256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/10/Screenshot_from_2017-10-18_12-32-23.png"}],
+        "origin": "snapcrafters", "package_name": "brackets", "publisher": "Snapcrafters",
+        "sections": [{"featured": true, "name": "development"}], "summary": "Brackets
+        is a modern code editor for HTML, CSS and JavaScript.", "title": "Brackets"},
+        {"apps": ["mpv"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/04/mpv-256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/04/mpv-256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/08/Selection_008.png"}],
+        "origin": "casept", "package_name": "mpv-casept", "publisher": "David Paskevic",
+        "sections": [{"featured": true, "name": "photo-and-video"}], "summary": "DEPRECEATED.
+        USE THE mpv SNAP INSTEAD.", "title": "mpv-casept"}, {"apps": ["insomnia"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/04/twitter-card-icon.png",
+        "media": [{"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/main.png"},
+        {"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/04/twitter-card-icon.png"}],
+        "origin": "gschier1990", "package_name": "insomnia", "publisher": "Gregory
+        Schier", "sections": [{"featured": true, "name": "development"}], "summary":
+        "Insomnia REST Client", "title": "Insomnia"}, {"apps": ["aldo"], "developer_validation":
+        "unproven", "icon_url": "", "media": [], "origin": "bh1scw", "package_name":
+        "aldo", "publisher": "FJKong", "sections": [{"featured": true, "name": "education"}],
+        "summary": "Aldo is a morse code learning tool released under GPL.", "title":
+        "aldo"}, {"apps": ["atomify"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2017/06/atomify_logo_256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/06/atomify_logo_256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/08/atomify.png"}],
+        "origin": "ovilab", "package_name": "atomify", "publisher": "Ovilab", "sections":
+        [{"featured": true, "name": "science"}], "summary": "Atomify LAMMPS", "title":
+        "Atomify LAMMPS"}, {"apps": ["sunwait"], "developer_validation": "unproven",
+        "icon_url": "", "media": [], "origin": "popey", "package_name": "sunwait",
+        "publisher": "Alan Pope", "sections": [{"featured": true, "name": "news-and-weather"},
+        {"featured": false, "name": "science"}], "summary": "Sunwait is a program
+        for calculating sunrise and sunset", "title": "Sunwait"}, {"apps": ["irssi"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/07/256irssi.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/07/256irssi.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/07/Screenshot_from_2018-07-02_14-27-15.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/07/Screenshot_from_2018-07-02_14-26-01.png"}],
+        "origin": "snapcrafters", "package_name": "irssi", "publisher": "Snapcrafters",
+        "sections": [{"featured": false, "name": "social"}], "summary": "The IRC client
+        of the future", "title": "irssi"}, {"apps": ["skrifa"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/12/icon_24.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/12/icon_24.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/Screenshot_from_2017-01-06_10-27-42.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/Screenshot_from_2017-01-06_10-29-26.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/Screenshot_from_2017-01-06_10-29-48.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/Screenshot_from_2017-01-06_10-30-02.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/Screenshot_from_2017-01-07_18-42-53.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/Screenshot_from_2017-01-07_18-43-19.png"}],
+        "origin": "hyuchia", "package_name": "skrifa", "publisher": "Hyuchia Diego",
+        "sections": [{"featured": false, "name": "productivity"}], "summary": "A simple
+        word processor built with web technologies", "title": "Skrifa"}, {"apps":
+        ["bw"], "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/256x256_I95tSNJ.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/256x256_I95tSNJ.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/Capture.PNG"}],
+        "origin": "bitwarden", "package_name": "bw", "publisher": "8bit Solutions
+        LLC", "sections": [{"featured": false, "name": "utilities"}], "summary": "A
+        secure and free password manager for all of your devices.", "title": "Bitwarden
+        CLI"}, {"apps": ["clion"], "developer_validation": "verified", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/clion.ico.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/clion.ico.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/Screen_Shot_2017-12-20_at_19.40.03.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/Screen_Shot_2017-12-20_at_20.37.09.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/Screen_Shot_2017-12-20_at_20.30.54.png"}],
+        "origin": "jetbrains", "package_name": "clion", "publisher": "jetbrains",
+        "sections": [{"featured": false, "name": "development"}], "summary": "A cross-platform
+        IDE for C and C++", "title": "CLion"}, {"apps": ["howdoi"], "developer_validation":
+        "unproven", "icon_url": "", "media": [], "origin": "simosx", "package_name":
+        "howdoi", "publisher": "Simos Xenitellis", "sections": [{"featured": false,
+        "name": "books-and-reference"}], "summary": "instant coding answers via the
+        command line", "title": "howdoi"}, {"apps": ["pycharm-educational"], "developer_validation":
+        "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/PyCharmEdu256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/PyCharmEdu256.png"}],
+        "origin": "jetbrains", "package_name": "pycharm-educational", "publisher":
+        "jetbrains", "sections": [{"featured": false, "name": "development"}], "summary":
+        "Easy and Professional Tool to Learn & Teach Programming with Python", "title":
+        "PyCharm EDU"}, {"apps": ["monento"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/icon_256x256_6tATclo.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/icon_256x256_6tATclo.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/1_Personal_finances.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/2_Track_money.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/3_Find_out_expenses.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/4_Know_how_much.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/5_Sync_N69FzV9.png"}],
+        "origin": "ladnysoft", "package_name": "monento", "publisher": "LadnySoft",
+        "sections": [{"featured": false, "name": "finance"}], "summary": "Cross-platform
+        app for tracking personal finances with encrypted data syncing.", "title":
+        "Monento"}, {"apps": ["telegram-cli"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/04/telegram-cli-icon1.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/04/telegram-cli-icon1.png"}],
+        "origin": "marius-quabeck", "package_name": "telegram-cli", "publisher": "Marius
+        Quabeck", "sections": [{"featured": false, "name": "social"}], "summary":
+        "Command-line interface for Telegram. Uses the readline interface.", "title":
+        "telegram-cli"}, {"apps": ["code-insiders", "url-handler"], "developer_validation":
+        "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/code512.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/code512.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/home-screenshot-linux.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/intellisense_b.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/peek_b.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/debug_b.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/git_b.png"}],
+        "origin": "vscode", "package_name": "code-insiders", "publisher": "Visual
+        Studio Code", "sections": [{"featured": false, "name": "development"}], "summary":
+        "Code editing. Redefined.", "title": "Visual Studio Code - Insiders"}, {"apps":
+        [], "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/07/ffmpeg256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/07/ffmpeg256.png"}],
+        "origin": "canonical", "package_name": "chromium-ffmpeg", "publisher": "Canonical",
+        "sections": [], "summary": "FFmpeg codecs (free and proprietary) for use by
+        third-party browser snaps", "title": "Chromium FFmpeg codecs"}, {"apps": ["gedit"],
+        "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/07/gedit.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/07/gedit.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/07/Screenshot_from_2017-07-19_15-25-40.png"}],
+        "origin": "canonical", "package_name": "gedit", "publisher": "Canonical",
+        "sections": [{"featured": false, "name": "development"}, {"featured": false,
+        "name": "productivity"}], "summary": "Edit text files", "title": "Text Editor"},
+        {"apps": ["standard-notes"], "developer_validation": "verified", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/Blue-Rounded-512.png",
+        "media": [{"height": 512, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/Blue-Rounded-512.png",
+        "width": 512}, {"height": 1060, "type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/Banner.png",
+        "width": 3180}, {"height": 658, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/Screenshot_1.png",
+        "width": 1170}, {"height": 658, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/Screenshot_2.png",
+        "width": 1170}, {"height": 658, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/Screenshot_3.png",
+        "width": 1170}, {"height": 658, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/Screenshot_4.png",
+        "width": 1170}], "origin": "standardnotes", "package_name": "standard-notes",
+        "publisher": "Standard Notes", "sections": [{"featured": false, "name": "productivity"}],
+        "summary": "Encrypted note-taking for all your devices.", "title": "Standard
+        Notes"}, {"apps": ["umbrello"], "developer_validation": "verified", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/umbrello.svg.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/umbrello.svg.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/umbrello.png"}],
+        "origin": "kde", "package_name": "umbrello", "publisher": "KDE", "sections":
+        [{"featured": false, "name": "development"}], "summary": "UML modelling tool
+        and code generator", "title": "Umbrello"}, {"apps": ["rider"], "developer_validation":
+        "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/snap-icon.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/snap-icon.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/rider1.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/rider2.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/rider3.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/rider0.png"}],
+        "origin": "jetbrains", "package_name": "rider", "publisher": "jetbrains",
+        "sections": [{"featured": false, "name": "development"}, {"featured": false,
+        "name": "utilities"}], "summary": "A fast & powerful cross-platform .NET IDE",
+        "title": "Rider"}, {"apps": ["kate"], "developer_validation": "verified",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/10/kate.svg.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/10/kate.svg.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/kate.png"}],
+        "origin": "kde", "package_name": "kate", "publisher": "KDE", "sections": [],
+        "summary": "KDE Advanced Text Editor", "title": "kate"}, {"apps": [], "developer_validation":
+        "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/snapd.png",
+        "media": [{"height": 460, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/snapd.png",
+        "width": 460}, {"height": 648, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/Screenshot_20190924_115756_hLcyetO.png",
+        "width": 956}, {"height": 648, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/Screenshot_20190924_115824_2v3y6l8.png",
+        "width": 956}, {"height": 834, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/Screenshot_20190924_115055_Uuq7KIb.png",
+        "width": 1023}, {"height": 648, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/Screenshot_20190924_125944.png",
+        "width": 956}], "origin": "canonical", "package_name": "snapd", "publisher":
+        "Canonical", "sections": [], "summary": "Background service that manages and
+        maintains installed snaps", "title": "snapd"}, {"apps": ["iwspy", "iwconfig",
+        "rfkill", "iwgetid", "iwpriv", "iw", "iwevent"], "developer_validation": "verified",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/icon_19.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/icon_19.png"}],
+        "origin": "canonical", "package_name": "wireless-tools", "publisher": "Canonical",
+        "sections": [], "summary": "Tools for manipulating Linux Wireless Extensions",
+        "title": "wireless-tools"}, {"apps": ["goland"], "developer_validation": "verified",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/go_1282x.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/11/go_1282x.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/go_overview.png"}],
+        "origin": "jetbrains", "package_name": "goland", "publisher": "jetbrains",
+        "sections": [{"featured": false, "name": "development"}], "summary": "A Clever
+        IDE to Go", "title": "GoLand"}, {"apps": ["space"], "developer_validation":
+        "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/ezgif.com-gif-maker.png",
+        "media": [{"height": 512, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/ezgif.com-gif-maker.png",
+        "width": 512}, {"height": 1860, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/home_for_teams.png",
+        "width": 2880}, {"height": 1638, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/collaborate_on_code_in_place.png",
+        "width": 2880}, {"height": 1736, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/issue_tracking.png",
+        "width": 2880}], "origin": "jetbrains", "package_name": "space", "publisher":
+        "jetbrains", "sections": [{"featured": false, "name": "development"}], "summary":
+        "Desktop Application for JetBrains Space", "title": "Space"}, {"apps": ["irccloud"],
+        "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/icon_fvVGr52.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/icon_fvVGr52.png"},
+        {"height": 1296, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/4a4675a8-7246-46b6-9d64-183a990b49f9.png",
+        "width": 2340}, {"height": 1296, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/e6ffefaa-8ecc-402f-8037-1b72112b43aa.png",
+        "width": 2340}, {"height": 1296, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/e2d56fdb-1c99-4099-9e5a-5af17cc5885b.png",
+        "width": 2340}], "origin": "irccloud", "package_name": "irccloud", "publisher":
+        "IRCCloud", "sections": [{"featured": false, "name": "productivity"}, {"featured":
+        false, "name": "social"}], "summary": "An IRC client with a future. Stay connected,
+        chat from anywhere, and never miss a message", "title": "IRCCloud"}, {"apps":
+        ["dotnet"], "developer_validation": "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/msft.net_256_8NLBkoS.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/msft.net_256_8NLBkoS.png"}],
+        "origin": "dotnetcore", "package_name": "dotnet-sdk", "publisher": "Microsoft
+        .NET Core", "sections": [{"featured": false, "name": "development"}], "summary":
+        "Develop high performance applications in less time, on any platform.", "title":
+        ".NET Core SDK"}, {"apps": ["qmi-network", "qmicli", "mbim-network", "mbimcli",
+        "mmcli"], "developer_validation": "verified", "icon_url": "", "media": [],
+        "origin": "canonical", "package_name": "modem-manager", "publisher": "Canonical",
+        "sections": [{"featured": false, "name": "devices-and-iot"}], "summary": "ModemManager
+        is a service which controls mobile broadband", "title": "modem-manager"},
+        {"apps": [], "developer_validation": "verified", "icon_url": "", "media":
+        [], "origin": "canonical", "package_name": "ofono", "publisher": "Canonical",
+        "sections": [], "summary": "Mobile telephony daemon", "title": "ofono"}, {"apps":
+        ["shyaml", "snap-revision", "bugsurfer", "setup-snap-repo", "flightschedule"],
+        "developer_validation": "verified", "icon_url": "", "media": [], "origin":
+        "canonical", "package_name": "se-dev-tools", "publisher": "Canonical", "sections":
+        [], "summary": "A set of utilities that help make working with our team snaps
+        easier", "title": "se-dev-tools"}, {"apps": [], "developer_validation": "verified",
+        "icon_url": "", "media": [], "origin": "canonical", "package_name": "gucharmap-udt",
+        "publisher": "Canonical", "sections": [], "summary": "Unicode character picker
+        and font browser", "title": "gucharmap-udt"}, {"apps": ["simple-obex-agent"],
+        "developer_validation": "verified", "icon_url": "", "media": [], "origin":
+        "canonical", "package_name": "bluez-tests", "publisher": "Canonical", "sections":
+        [], "summary": "Set of utilities that are not production ready yet help in
+        testing", "title": "bluez-tests"}, {"apps": ["alsa-utils", "udisks2", "run",
+        "plainbox", "tpm", "pulseaudio", "network-manager", "bluez", "wifi-ap", "upower",
+        "modem-manager", "media-hub", "wireless-tools"], "developer_validation": "verified",
+        "icon_url": "", "media": [], "origin": "canonical", "package_name": "canonical-se-engineering-tests",
+        "publisher": "Canonical", "sections": [], "summary": "Canonical System Enablement
+        Engineering Test cases", "title": "canonical-se-engineering-tests"}, {"apps":
+        ["qr-code-generator-desktop"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/icon_P7afCqs.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/icon_P7afCqs.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/screenshot-1_sjeP5p2.png"}],
+        "origin": "studiolacosanostra", "package_name": "qr-code-generator-desktop",
+        "publisher": "Studio La Cosa Nostra", "sections": [{"featured": false, "name":
+        "utilities"}], "summary": "Create custom QR Codes. You can save them as PNG
+        image. You can change the size of the image.", "title": "QR Code Generator"},
+        {"apps": ["codenamelt"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/icon_256x256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/icon_256x256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/screenshot_snap.png"}],
+        "origin": "eri0o", "package_name": "codenamelt", "publisher": "erico_pt",
+        "sections": [{"featured": false, "name": "games"}], "summary": "A pixelart
+        game where you have to run without getting caught by evil agents.", "title":
+        "codenamelt"}, {"apps": ["codedoc"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/codedoc-256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/codedoc-256.png"}],
+        "origin": "michaelrsweet", "package_name": "codedoc", "publisher": "Michael
+        Sweet", "sections": [{"featured": false, "name": "utilities"}], "summary":
+        "Code documentation utility.", "title": "codedoc"}, {"apps": ["ampareqrcodelinux"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/qr-code.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/qr-code.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/Screenshot_2018-02-11_01-50-38.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/Screenshot_2018-02-11_01-50-30.png"}],
+        "origin": "juthawong", "package_name": "ampareqrcodelinux", "publisher": "Juthawong
+        Naisanguansee", "sections": [], "summary": "Create Your Own QR Code From Any
+        Text and Save", "title": "Ampare QR Code Creator"}, {"apps": ["prettier"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/prettier-icon-dark.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/prettier-icon-dark.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/screenshot_nFeUCLQ.png"}],
+        "origin": "sangbum", "package_name": "prettier", "publisher": "Sangbum Kim",
+        "sections": [], "summary": "Prettier is an opinionated code formatter", "title":
+        "prettier"}, {"apps": ["scc"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/icon_PvPKbUH.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/icon_PvPKbUH.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/screenshot_bwlDNiR.png"}],
+        "origin": "felicianotech", "package_name": "scc", "publisher": "Ricardo N
+        Feliciano", "sections": [{"featured": false, "name": "development"}], "summary":
+        "scc is a very fast & accurate code counter counting lines of code by language.",
+        "title": "scc"}, {"apps": ["line-calc"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/03/icon_7.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/03/icon_7.png"}],
+        "origin": "quasarapp", "package_name": "line-calc", "publisher": "Andrei Yancovich",
+        "sections": [], "summary": "Utility for counting the number of lines in a
+        project.", "title": "Line Calc"}, {"apps": ["gisto"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/icon_60sKxPN.png",
+        "media": [{"height": 512, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/icon_60sKxPN.png",
+        "width": 512}, {"height": 1600, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/Jx8Tc9s.png",
+        "width": 2560}, {"height": 1600, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/yiEJRNt.png",
+        "width": 2560}, {"height": 1600, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/JtUCsfI.png",
+        "width": 2560}, {"height": 1600, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/Aac48m9.png",
+        "width": 2560}, {"height": 1600, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/bXySAUt.png",
+        "width": 2560}], "origin": "gisto", "package_name": "gisto", "publisher":
+        "Gisto", "sections": [{"featured": false, "name": "development"}, {"featured":
+        false, "name": "productivity"}], "summary": "Code snippet manager, runs on
+        GitHub Gists and adds additional features such as searching, tagging gists
+        with rich code editor.", "title": "Gisto"}, {"apps": ["amparetraceroute"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/04/trace.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/04/trace.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/04/Screenshot_2018-04-19_18-14-20.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/04/Screenshot_2018-04-19_18-13-28.png"}],
+        "origin": "juthawong", "package_name": "amparetraceroute", "publisher": "Juthawong
+        Naisanguansee", "sections": [], "summary": "Trace HTTP Route and Display Result",
+        "title": "Ampare HTTP Trace Route"}, {"apps": ["broker"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/apibillme_copy_tdEZI5g.png",
+        "media": [{"height": 256, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/apibillme_copy_tdEZI5g.png",
+        "width": 256}, {"height": 500, "type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/1500x500.jpeg",
+        "width": 1500}], "origin": "bevanhunt", "package_name": "broker", "publisher":
+        "Bevan Hunt", "sections": [{"featured": false, "name": "server-and-cloud"}],
+        "summary": "Real-time Zero-Code API Server", "title": "broker"}, {"apps":
+        ["cppcheck"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/cppcheck.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/cppcheck.png"}],
+        "origin": "cking-kernel-tools", "package_name": "cppcheck", "publisher": "Colin
+        King", "sections": [{"featured": false, "name": "development"}], "summary":
+        "A tool for static C/C++ code analysis", "title": "cppcheck"}, {"apps": ["zig"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/zig-icon.svg.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/zig-icon.svg.png"}],
+        "origin": "jayschwa", "package_name": "zig", "publisher": "Jay Petacat", "sections":
+        [{"featured": false, "name": "development"}], "summary": "Zig Programming
+        Language", "title": "Zig"}, {"apps": ["packer"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/04/packer-abacao.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/04/packer-abacao.png"}],
+        "origin": "abacao", "package_name": "packer-abacao", "publisher": "Andr\u00e9
+        Ba\u00e7\u00e3o", "sections": [], "summary": "Packer - Build Automated Machine
+        Images", "title": "packer-abacao"}, {"apps": ["cppcheckgui"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/cppcheck-gui.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/cppcheck-gui.png"}],
+        "origin": "gocarlos", "package_name": "cppcheckgui", "publisher": "Carlos
+        Gomes Martinho", "sections": [], "summary": "A tool for static C/C++ code
+        analysis", "title": "cppcheckgui"}, {"apps": ["rdplot"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/PLOT256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/PLOT256.png"}],
+        "origin": "schneider-p", "package_name": "rdplot", "publisher": "Jens Schneider",
+        "sections": [], "summary": "The plotting tool for rate distortion curves in
+        the context of video coding.", "title": "rdplot"}, {"apps": ["amparecssrandomcolor"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/icon_qBUklKz.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/icon_qBUklKz.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/Screenshot_from_2018-09-04_22-29-53.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/Screenshot_from_2018-09-04_22-29-36.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/Screenshot_from_2018-09-04_22-28-59.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/Screenshot_from_2018-09-04_22-28-46.png"}],
+        "origin": "juthawong", "package_name": "amparecssrandomcolor", "publisher":
+        "Juthawong Naisanguansee", "sections": [], "summary": "Random Color with CSS
+        Hexadecimal Code For Next Web Design Idea", "title": "Ampare Random CSS Color"},
+        {"apps": ["puppetry"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/puppetry-256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/puppetry-256.png"},
+        {"height": 400, "type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/main-1x3.png",
+        "width": 1200}, {"height": 720, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/main_VoewqIW.png",
+        "width": 1200}, {"height": 720, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/article-relative-position.png",
+        "width": 1200}, {"height": 720, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/article-report-ok.png",
+        "width": 1200}, {"height": 720, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/article-css-regression.png",
+        "width": 1200}], "origin": "dsheiko", "package_name": "puppetry", "publisher":
+        "Dzmitry Sheiko", "sections": [{"featured": false, "name": "development"},
+        {"featured": false, "name": "utilities"}], "summary": "Puppetry - codeless
+        end-to-end test automation, integrated with CI/CD pipeline", "title": "Puppetry"},
+        {"apps": ["python-vvv", "report", "python-add-root", "python", "report-add-root",
+        "python-v", "pynsource", "python-add-site", "report-add-site"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/G12-Folder-Doc-icon.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/G12-Folder-Doc-icon.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/pynsource-mbp-screen-python.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/pynsource-zoom-line-edit.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/pynsource-ascii_uml.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/2019-03-02_12-15-04-1.gif"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/pynsource-plantuml-2.png"}],
+        "origin": "andybulka", "package_name": "pynsource", "publisher": "Andy", "sections":
+        [{"featured": false, "name": "development"}], "summary": "Pynsource - reverse
+        engineer Python source code into UML", "title": "Pynsource - UML tool for
+        Python"}, {"apps": ["qxmledit"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/qxmledit.svg.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/qxmledit.svg.png"},
+        {"type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/QXmlEdit_Banner_Snap_Store.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/qxmledit-screenshot-800.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/anonymize.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/attribute_filter.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/base64.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/charinfo.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/codepages.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/comparexsd.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/editelement.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/encodings.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/heatmaps.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/relations.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/split.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/structure.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/xsd.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/xslt.png"}],
+        "origin": "frederickjh", "package_name": "qxmledit", "publisher": "Frederick
+        J. Henderson", "sections": [{"featured": false, "name": "development"}, {"featured":
+        false, "name": "utilities"}], "summary": "QXmlEdit is a simple XML editor
+        based on Qt libraries.", "title": "qxmledit"}, {"apps": ["rockscissorspaperlizardspock-snap"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/rockscissorspaperlizardspock-snap.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/rockscissorspaperlizardspock-snap.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/RSPLS-snap_screenshot1.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/RSPLS-snap_screenshot2.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/RSPLS-snap_screenshot3.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/RSPLS-snap_screenshot4.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/RSPLS-snap_screenshot5.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/RSPLS-snap_screenshot6.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/RSPLS-snap_screenshot7.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/01/RSPLS-snap_screenshot8.png"}],
+        "origin": "phelion", "package_name": "rockscissorspaperlizardspock-snap",
+        "publisher": "pHeLiOn", "sections": [], "summary": "2 player game of a variation
+        of ''Rock, Paper, Scissors''", "title": "rockscissorspaperlizardspock-snap"},
+        {"apps": ["e-tools"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/512.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/512.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/v1.3.6.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/english.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/chinese.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/russian.png"}],
+        "origin": "suremotoo", "package_name": "e-tools", "publisher": "Suremotoo",
+        "sections": [{"featured": false, "name": "development"}], "summary": "A toolbox
+        for developers. Color picker, code formatter, and more", "title": "E-tools"},
+        {"apps": ["gif2flif", "flif", "dflif", "viewflif", "apng2flif"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/index.png",
+        "media": [{"height": 512, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/index.png",
+        "width": 512}], "origin": "nevermine17", "package_name": "flif", "publisher":
+        "Danil Nikolaev", "sections": [{"featured": false, "name": "photo-and-video"},
+        {"featured": false, "name": "utilities"}], "summary": "All the tools you need
+        for the Free Lossless Image Format", "title": "FLIF - Free Lossless Image
+        Format"}, {"apps": ["authenticator"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/icon_6nLCgqR.png",
+        "media": [{"height": 128, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/icon_6nLCgqR.png",
+        "width": 128}], "origin": "jocave", "package_name": "authenticator-joc", "publisher":
+        "Jonathan Cave", "sections": [{"featured": false, "name": "security"}], "summary":
+        "A Two-Factor Authentication application", "title": "authenticator-joc"},
+        {"apps": ["daemon-testnet", "daemon", "cli-regtest", "cli", "tx", "qt-testnet",
+        "daemon-regtest", "cli-testnet", "qt-regtest", "qt"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/ion256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/ion256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/splash.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/multisig-overview.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/blockexplorer.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/commandline-options.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/options.png"}],
+        "origin": "ioncoin", "package_name": "ioncore", "publisher": "Ion coin developer",
+        "sections": [{"featured": false, "name": "finance"}, {"featured": false, "name":
+        "games"}], "summary": "gaming related peer-to-peer network based digital currency",
+        "title": "Ion Digital Currency (Official release)"}, {"apps": ["brackets"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/brackets.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/brackets.png"}],
+        "origin": "cprov", "package_name": "cprov-brackets", "publisher": "Celso Providelo",
+        "sections": [], "summary": "Brackets is a modern code editor for HTML, CSS
+        and JavaScript.", "title": "cprov-brackets"}, {"apps": ["hub"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/icon.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/icon.png"}],
+        "origin": "felicianotech", "package_name": "hub", "publisher": "Ricardo N
+        Feliciano", "sections": [{"featured": false, "name": "development"}], "summary":
+        "hub is a command-line wrapper for git that makes you better at GitHub.",
+        "title": "hub"}, {"apps": ["vokoscreen-ng"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/vokoscreen-ng.png",
+        "media": [{"height": 256, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/vokoscreen-ng.png",
+        "width": 256}, {"height": 483, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/02/Screenshot_from_2020-02-06_08-53-40.png",
+        "width": 730}, {"height": 483, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/02/Screenshot_from_2020-02-06_08-54-09.png",
+        "width": 730}, {"height": 483, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/02/Screenshot_from_2020-02-06_08-54-35.png",
+        "width": 730}], "origin": "popey", "package_name": "vokoscreen-ng", "publisher":
+        "Alan Pope", "sections": [{"featured": false, "name": "photo-and-video"},
+        {"featured": false, "name": "utilities"}], "summary": "vokoscreenNG", "title":
+        "vokoscreenNG"}, {"apps": ["color-picker"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/app.png",
+        "media": [{"height": 512, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/app.png",
+        "width": 512}, {"height": 708, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/pic_1.png",
+        "width": 530}, {"height": 705, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/pic_2.png",
+        "width": 929}], "origin": "keshavnrj", "package_name": "color-picker", "publisher":
+        "keshavbhatt", "sections": [{"featured": false, "name": "development"}, {"featured":
+        false, "name": "utilities"}], "summary": "A colour picker and colour editor
+        for web designers and digital artists", "title": "Color Picker"}, {"apps":
+        ["azimuth"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/azimuth480.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/azimuth480.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/Screenshot_20190412_214356.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/Screenshot_20190412_214437.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/Screenshot_20190412_214544.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/Screenshot_20190412_214704-1.png"}],
+        "origin": "popey", "package_name": "azimuth", "publisher": "Alan Pope", "sections":
+        [{"featured": false, "name": "games"}], "summary": "Azimuth - A metroidvania
+        with vector graphics", "title": "azimuth"}, {"apps": [], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/icon256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/icon256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/osddm.png"}],
+        "origin": "vs", "package_name": "osddm", "publisher": "vasilisc", "sections":
+        [{"featured": false, "name": "development"}], "summary": "Oracle SQL Developer
+        Data Modeler", "title": "osddm"}, {"apps": ["barriers", "barrierc", "barrier"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/08/icon.svg_JtFjzqW.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/08/icon.svg_JtFjzqW.png"}],
+        "origin": "adrianceleste", "package_name": "barrier", "publisher": "Adrian
+        Lucr\u00e8ce C\u00e9leste", "sections": [{"featured": false, "name": "productivity"}],
+        "summary": "Barrier - Share mouse and keyboard over the local network", "title":
+        "barrier"}, {"apps": ["sectrain"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/st-snapico.png",
+        "media": [{"height": 493, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/st-snapico.png",
+        "width": 493}, {"height": 500, "type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/st-banner.png",
+        "width": 1500}, {"height": 974, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/st-xss.png",
+        "width": 1804}, {"height": 974, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/st-home.png",
+        "width": 1804}, {"height": 974, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/st-install.png",
+        "width": 1804}, {"height": 974, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/st-py.png",
+        "width": 1804}], "origin": "joemcmanus", "package_name": "sectrain", "publisher":
+        "Joe McManus", "sections": [{"featured": false, "name": "education"}, {"featured":
+        false, "name": "security"}], "summary": "A training tool displaying some techniques
+        for secure web app development", "title": "sectrain"}, {"apps": ["yquake2",
+        "yquake2-launch"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/quake2.svg.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/quake2.svg.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/Bildschirmfoto_von_2018-08-25_17-09-46.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/Bildschirmfoto_von_2018-08-25_17-10-11.png"}],
+        "origin": "beidl", "package_name": "yamagi-quake2-beidl", "publisher": "Alfred
+        E. Neumayer", "sections": [], "summary": "An enhanced version of id Software''s
+        Quake II.", "title": "Yamagi Quake II"}, {"apps": ["kimitzu-client"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/icon_vwLGEQ1.png",
+        "media": [{"height": 512, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/icon_vwLGEQ1.png",
+        "width": 512}, {"height": 660, "type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/full-blue.png",
+        "width": 1980}, {"height": 1080, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/Screenshot_from_2020-01-22_09-53-27.png",
+        "width": 1920}, {"height": 1080, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/Screenshot_from_2020-01-22_12-38-04.png",
+        "width": 1920}], "origin": "kimitzu", "package_name": "kimitzu-client", "publisher":
+        "Kimitzu Foundation", "sections": [{"featured": false, "name": "utilities"}],
+        "summary": "Kimitzu Client: A free market for services", "title": "Kimitzu"},
+        {"apps": ["bussard"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/03/bussard_256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/03/bussard_256.png"}],
+        "origin": "popey", "package_name": "bussard", "publisher": "Alan Pope", "sections":
+        [], "summary": "Bussard", "title": "bussard"}, {"apps": ["gamecake", "grd",
+        "jam", "midi"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/09/gamecake.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/09/gamecake.png"},
+        {"height": 640, "type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/gcake.png",
+        "width": 1920}, {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/09/20170811_134606.png"},
+        {"height": 485, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/screen_2McWHe5.png",
+        "width": 648}, {"height": 512, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/screen_qhfNjQZ.png",
+        "width": 911}, {"height": 744, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/screen_6b6P2KQ.png",
+        "width": 1349}, {"height": 1056, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/screen_qlUaH1Y.png",
+        "width": 1920}], "origin": "xriss", "package_name": "gamecake", "publisher":
+        "kriss", "sections": [{"featured": false, "name": "development"}, {"featured":
+        false, "name": "games"}], "summary": "a single exe cross platform Lua game
+        engine", "title": "gamecake"}, {"apps": ["epictask"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/icon-256x256.png",
+        "media": [{"type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/epictask-banner.png"},
+        {"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/icon-256x256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/epictask-screen-01.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/epictask-screen-02.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/epictask-screen-03.png"}],
+        "origin": "densebrain", "package_name": "epictask", "publisher": "Densebrain,
+        Inc", "sections": [{"featured": false, "name": "development"}, {"featured":
+        false, "name": "utilities"}], "summary": "*Github* issues are your bitch!",
+        "title": "Epictask"}, {"apps": ["dspatcher"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/heartbeat.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/heartbeat.png"},
+        {"height": 723, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/08/DSPatcher_-_Screenshot.png",
+        "width": 1161}], "origin": "marcustomlinson", "package_name": "dspatcher",
+        "publisher": "Marcus Tomlinson", "sections": [{"featured": false, "name":
+        "music-and-audio"}, {"featured": false, "name": "science"}], "summary": "Cross-Platform
+        Graphical Tool for DSPatch", "title": "dspatcher"}, {"apps": ["wdos"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/snap.png",
+        "media": [{"height": 512, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/snap.png",
+        "width": 512}, {"height": 240, "type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/banner3.png",
+        "width": 720}, {"height": 600, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/Screenshot_from_2019-11-06_18-44-12.png",
+        "width": 800}, {"height": 600, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/Screenshot_from_2019-11-06_18-51-07.png",
+        "width": 800}, {"height": 600, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/Screenshot_from_2019-11-06_18-50-28.png",
+        "width": 800}, {"height": 600, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/Screenshot_from_2019-11-06_18-50-08.png",
+        "width": 800}, {"height": 600, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/Screenshot_from_2019-11-06_18-51-29.png",
+        "width": 800}], "origin": "webdeskme", "package_name": "wdos", "publisher":
+        "Adam Telford", "sections": [{"featured": false, "name": "utilities"}], "summary":
+        "WebDesktop (wdOS) is the easy way to make desktop apps with web languages
+        and nothing else!", "title": "wdos"}, {"apps": ["yabasanshiro", "bash"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/yabasanshiro.png",
+        "media": [{"height": 96, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/yabasanshiro.png",
+        "width": 96}, {"height": 692, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/main_V0oodIL.png",
+        "width": 798}, {"height": 720, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/about.png",
+        "width": 1280}], "origin": "devmiyax", "package_name": "yabasanshiro", "publisher":
+        "devMiyax", "sections": [{"featured": false, "name": "games"}], "summary":
+        "SEGA Saturn emulator", "title": "Yaba Sanshiro"}, {"apps": ["launcher", "fs-uae"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/10/fs-uae.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/10/fs-uae.png"}],
+        "origin": "jz", "package_name": "fsuae", "publisher": "Jacob Zimmermann",
+        "sections": [], "summary": "The FS-UAE Amiga Emulator", "title": "fsuae"},
+        {"apps": ["electron-mail"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/icon_736yZqT.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/icon_736yZqT.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/pm_window_BHxQKYW.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/export.gif"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/search.gif"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/keep-me-signed-in_FWcDSDN.png"}],
+        "origin": "joshirio", "package_name": "electron-mail", "publisher": "Oirio
+        Joshi", "sections": [{"featured": false, "name": "productivity"}, {"featured":
+        false, "name": "social"}], "summary": "Unofficial ProtonMail Desktop App",
+        "title": "ElectronMail"}, {"apps": ["simplescreenrecorder-brlin"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/icon_Y093431.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/icon_Y093431.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/welcome-screen_dqoddZe.png"}],
+        "origin": "brlin", "package_name": "simplescreenrecorder-brlin", "publisher":
+        "\u6797\u535a\u4ec1(Buo-ren, Lin)", "sections": [{"featured": false, "name":
+        "photo-and-video"}, {"featured": false, "name": "productivity"}], "summary":
+        "A feature-rich screen recorder", "title": "SimpleScreenRecorder (UNOFFICIAL)"},
+        {"apps": ["launcher"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/logocaprice32_256x256.jpeg.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/logocaprice32_256x256.jpeg.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/6_yTVtvvH.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/10.jpg"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/5_gZfeoYf.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/1_7m3Pfuq.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/4_tExkB4h.png"}],
+        "origin": "stanmichals", "package_name": "caprice32", "publisher": "Stan MICHALSKI",
+        "sections": [{"featured": false, "name": "games"}], "summary": "Amstrad CPC
+        emulator", "title": "Caprice32 Amstrad CPC emulator"}, {"apps": ["mini-diary"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/app-icon-256.png",
+        "media": [{"height": 256, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/app-icon-256.png",
+        "width": 256}, {"height": 1424, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/screenshot-1.png",
+        "width": 2424}, {"height": 1424, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/screenshot-2_8kJejRx.png",
+        "width": 2424}, {"height": 1424, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/screenshot-3.png",
+        "width": 2424}, {"height": 1424, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/screenshot-4.png",
+        "width": 2424}], "origin": "samuelmeuli", "package_name": "mini-diary", "publisher":
+        "Samuel Meuli", "sections": [{"featured": false, "name": "art-and-design"},
+        {"featured": false, "name": "utilities"}], "summary": "Simple and secure journal
+        app", "title": "Mini Diary"}, {"apps": ["remote-touchpad", "remote-touchpad-wait-on-error"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/remote-touchpad_128.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/remote-touchpad_128.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/1_LG87LOD.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/2_XBV80lx.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/3_R8IV0uS.png"},
+        {"height": 533, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/02/4_b1PV3pC.png",
+        "width": 706}], "origin": "unrud", "package_name": "remote-touchpad", "publisher":
+        "unrud", "sections": [{"featured": false, "name": "utilities"}], "summary":
+        "Control mouse and keyboard from a smartphone", "title": "Remote Touchpad"},
+        {"apps": ["p7zip-desktop"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/7zip.png", "media":
+        [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/7zip.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/Screenshot_20181015_211036.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/Screenshot_20181012_161957_IUxlNpb.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/Screenshot_20181012_161908_3Wez9nx.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/Screenshot_20181012_161844_OfDqI2S.png"}],
+        "origin": "ernytech", "package_name": "p7zip-desktop", "publisher": "Ermesto
+        Castellotti", "sections": [{"featured": false, "name": "utilities"}], "summary":
+        "P7Zip - Desktop", "title": "P7Zip - Desktop"}, {"apps": ["instagramport"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/messengermin.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/messengermin.png"}],
+        "origin": "cyber456", "package_name": "instagramport", "publisher": "Andrius
+        Pratusis", "sections": [{"featured": false, "name": "social"}], "summary":
+        "Simple and light Instagram Desktop App. Hope that you''ll like it.", "title":
+        "instagramport"}, {"apps": ["freaccmd", "freac"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/freac-256x256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/freac-256x256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/freac-linux.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/freac-linux-tageditor.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/freac-linux-settings.png"}],
+        "origin": "enzo1982", "package_name": "freac", "publisher": "Robert Kausch",
+        "sections": [{"featured": false, "name": "music-and-audio"}], "summary": "Audio
+        converter and CD ripper", "title": "fre:ac"}, {"apps": ["pocket-casts"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/icon-x256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/icon-x256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/banner_7v679Au.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/screenshot-fullscreen-3200x1800.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/screenshot-new-releases-2000x1314.png"}],
+        "origin": "felicianotech", "package_name": "pocket-casts", "publisher": "Ricardo
+        N Feliciano", "sections": [], "summary": "The Pocket Casts webapp, packaged
+        for the desktop.", "title": "Pocket Casts"}, {"apps": ["gdax-trading-bot"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/Bitcoin_256x256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/Bitcoin_256x256.png"},
+        {"height": 691, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/Screenshot_from_2019-11-21_10-53-47.png",
+        "width": 1135}, {"height": 951, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/Screenshot_from_2019-11-21_10-55-53.png",
+        "width": 1673}], "origin": "kenshiro-gohan", "package_name": "gdax-trading-bot",
+        "publisher": "Kenshiro", "sections": [{"featured": false, "name": "finance"},
+        {"featured": false, "name": "utilities"}], "summary": "Trading bot for the
+        Coinbase Pro exchange", "title": "GDAX Trading Bot"}, {"apps": ["bolls"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/favicon-512x512.png",
+        "media": [{"height": 512, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/favicon-512x512.png",
+        "width": 512}, {"height": 640, "type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/banner_45Cnyjf.png",
+        "width": 1920}, {"height": 900, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/Screenshot_from_2020-01-26_09-08-06.png",
+        "width": 1600}, {"height": 900, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/Screenshot_from_2020-01-26_09-08-14.png",
+        "width": 1600}, {"height": 900, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/Screenshot_from_2020-01-26_09-08-28.png",
+        "width": 1600}, {"height": 900, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/Screenshot_from_2020-01-26_09-09-03.png",
+        "width": 1600}, {"height": 900, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/Screenshot_from_2020-01-26_09-09-09.png",
+        "width": 1600}], "origin": "boguslav", "package_name": "bolls", "publisher":
+        "\u0411\u043e\u0433\u0443\u0441\u043b\u0430\u0432 \u041f\u0430\u0432\u043b\u0438\u0448\u0438\u043d\u0435\u0446\u044c",
+        "sections": [{"featured": false, "name": "books-and-reference"}, {"featured":
+        false, "name": "social"}], "summary": "Bolls app for reading Bible", "title":
+        "Bolls"}, {"apps": ["cpp-dependencies"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/1200px-ISO_C___Logo.svg.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/1200px-ISO_C___Logo.svg.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/prometheus.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/dependencies.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/newdependencies.png"}],
+        "origin": "gocarlos", "package_name": "cpp-dependencies", "publisher": "Carlos
+        Gomes Martinho", "sections": [{"featured": false, "name": "development"},
+        {"featured": false, "name": "utilities"}], "summary": "cpp-dependencies",
+        "title": "cpp-dependencies"}, {"apps": ["flawfinder"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/flawfinder_OBvvmS1.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/flawfinder_OBvvmS1.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/Screenshot_from_2018-11-01_17-52-47.png"}],
+        "origin": "cking-kernel-tools", "package_name": "flawfinder-static-analyzer",
+        "publisher": "Colin King", "sections": [], "summary": "C static analyzer tool",
+        "title": "flawfinder-static-analyzer"}, {"apps": ["smallrnaseq"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/logo.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/logo.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/scr0.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/scr1.png"}],
+        "origin": "dmnfarrell", "package_name": "smallrnaseq", "publisher": "Damien
+        Farrell", "sections": [{"featured": false, "name": "science"}], "summary":
+        "command line tool for small rna seq analysis", "title": "smallrnaseq"}, {"apps":
+        ["tool", "find", "proxy", "server", "eveprinter"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/ipp.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/ipp.png"}],
+        "origin": "michaelrsweet", "package_name": "ipp", "publisher": "Michael Sweet",
+        "sections": [], "summary": "IPP Sample Implementation and Tools", "title":
+        "IPP Sample Implementation and Tools"}, {"apps": ["ubuntu-iso-download"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/iso-download-256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/iso-download-256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/iso-download.gif"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/iso-download-example.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/iso-download-help.png"}],
+        "origin": "powersj", "package_name": "ubuntu-iso-download", "publisher": "Joshua
+        Powers", "sections": [{"featured": false, "name": "development"}, {"featured":
+        false, "name": "utilities"}], "summary": "Download the latest Ubuntu ISOs",
+        "title": "Ubuntu ISO Download"}, {"apps": ["carnet"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/web-icon256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/11/web-icon256.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/Capture_d%C3%A9cran_du_2018-12-18_01.28.19.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/Capture_d%C3%A9cran_du_2018-12-23_21.42.09.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/Capture_d%C3%A9cran_du_2018-12-18_02.08.31.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/mediamanager_QmlUq80.png"}],
+        "origin": "alexandre-roux-m", "package_name": "carnet", "publisher": "Alexandre
+        Roux", "sections": [], "summary": "Powerful note taking app with sync, online
+        editor and android app", "title": "Carnet"}, {"apps": ["android-studio-canary"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/studio420.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/studio420.png"}],
+        "origin": "snapcrafters", "package_name": "android-studio-canary", "publisher":
+        "Snapcrafters", "sections": [{"featured": false, "name": "development"}],
+        "summary": "The IDE for Android (Canary build)", "title": "Android Studio
+        Canary"}, {"apps": ["epiphany"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/org.gnome.Epiphany.svg.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/org.gnome.Epiphany.svg.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/screenshot_c3MqzdZ.png"}],
+        "origin": "jbicha", "package_name": "epiphany", "publisher": "Jeremy Bicha",
+        "sections": [{"featured": false, "name": "productivity"}], "summary": "Web
+        browser for GNOME", "title": "GNOME Web"}, {"apps": [], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/cdbc.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/cdbc.png"}],
+        "origin": "fnordahl", "package_name": "cdbc", "publisher": "Frode Nordahl",
+        "sections": [{"featured": false, "name": "development"}], "summary": "C library
+        providing simple and easy to use interfaces to the ODBC API", "title": "cdbc"},
+        {"apps": ["electronim"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/02/icon_IdzZ6u6.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/02/icon_IdzZ6u6.png"},
+        {"height": 751, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/02/WhatsApp.png",
+        "width": 933}, {"height": 664, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/02/main.png",
+        "width": 923}, {"height": 751, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/02/gitter.png",
+        "width": 1107}, {"height": 751, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/02/settings.png",
+        "width": 933}], "origin": "marcnuri", "package_name": "electronim", "publisher":
+        "Marc Nuri", "sections": [{"featured": false, "name": "social"}, {"featured":
+        false, "name": "utilities"}], "summary": "Free/Libre open source Electron
+        based multi instant messaging (IM) client.", "title": "ElectronIM"}, {"apps":
+        ["eric"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/icon_XpZYP1Z.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/icon_XpZYP1Z.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/eric5-screen-01.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/eric5-screen-02.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/eric5-screen-06.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/eric5-screen-07.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/eric5-screen-13.png"}],
+        "origin": "makarovdenis11", "package_name": "eric-ide", "publisher": "Denis",
+        "sections": [{"featured": false, "name": "development"}], "summary": "Eric
+        python IDE", "title": "Eric python IDE"}, {"apps": ["brs-emu-app"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/10/512x512.png",
+        "media": [{"height": 512, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/10/512x512.png",
+        "width": 512}, {"height": 550, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/10/Screenshot_from_2019-10-04_20-36-48.png",
+        "width": 900}, {"height": 550, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/10/Screenshot_from_2019-10-04_20-39-33.png",
+        "width": 900}], "origin": "lvcabral", "package_name": "brs-emu-app", "publisher":
+        "Marcelo Lv Cabral", "sections": [{"featured": false, "name": "development"},
+        {"featured": false, "name": "utilities"}], "summary": "BrightScript 2D API
+        Emulator", "title": "BrightScript 2D API Emulator"}, {"apps": ["drakon", "tclsh"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/12/icon.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/12/icon.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/12/drakon1.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/12/drakon2.png"}],
+        "origin": "vs", "package_name": "drakon", "publisher": "vasilisc", "sections":
+        [], "summary": "DRAKON Editor is a free tool for authoring diagrams.", "title":
+        "drakon"}, {"apps": ["spek"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2020/02/spek.png", "media":
+        [{"height": 465, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/02/spek.png",
+        "width": 465}, {"height": 619, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/02/spek_Q5t56Va.png",
+        "width": 923}], "origin": "popey", "package_name": "spek", "publisher": "Alan
+        Pope", "sections": [{"featured": false, "name": "music-and-audio"}, {"featured":
+        false, "name": "utilities"}], "summary": "Acoustic Spectrum Analyser", "title":
+        "Spek"}, {"apps": ["neverbore"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2017/02/icon_4.png", "media":
+        [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/02/icon_4.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/02/screenshot20150616_000934740.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/02/screenshot20150616_001242407.png"}],
+        "origin": "mterry", "package_name": "neverbore", "publisher": "Michael Terry",
+        "sections": [{"featured": false, "name": "games"}], "summary": "A picture
+        logic puzzle game", "title": "Neverbore Picross"}, {"apps": ["redirect-to"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/icon.svg_mS7EJSV.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/icon.svg_mS7EJSV.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/redirect_ui.png"}],
+        "origin": "reddec", "package_name": "redirect-to", "publisher": "Baryshnikov
+        Aleksandr", "sections": [{"featured": false, "name": "devices-and-iot"}, {"featured":
+        false, "name": "server-and-cloud"}], "summary": "Simple, very fast, in a single
+        binary, with web UI HTTP redirect service", "title": "redirect-to"}, {"apps":
+        ["amqp-send", "amqp-recv", "amqp-exec"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/icon.svg_EZ9MDgA.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/icon.svg_EZ9MDgA.png"}],
+        "origin": "reddec", "package_name": "fluent-amqp", "publisher": "Baryshnikov
+        Aleksandr", "sections": [{"featured": false, "name": "utilities"}], "summary":
+        "AMQP utilities", "title": "fluent-amqp"}, {"apps": ["messengerport"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/messenger.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/messenger.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/Screenshot_from_2019-04-02_23-04-09.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/Screenshot_from_2019-04-02_23-04-22.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/Screenshot_from_2019-04-03_16-38-31.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/Screenshot_from_2019-05-07_13-34-02.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/messenger_D5LSPUw.png"}],
+        "origin": "cyber456", "package_name": "messengerport", "publisher": "Andrius
+        Pratusis", "sections": [{"featured": false, "name": "productivity"}, {"featured":
+        false, "name": "social"}], "summary": "Simple and smart Facebook Messenger
+        Desktop App. Hope that you''ll like it.", "title": "Facebook messenger port"},
+        {"apps": ["gosec"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/02/68747470733a2f2f736563757265676f2e696f2f696d672f676f7365632e706e67.png",
+        "media": [{"height": 512, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/02/68747470733a2f2f736563757265676f2e696f2f696d672f676f7365632e706e67.png",
+        "width": 512}], "origin": "alexmurray", "package_name": "gosec", "publisher":
+        "Alex Murray", "sections": [{"featured": false, "name": "utilities"}], "summary":
+        "Golang Security Checker", "title": "gosec"}, {"apps": ["ampareinvertcolor"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/icon_uwYFqpn.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/icon_uwYFqpn.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/Screenshot_from_2018-05-24_23-18-17.png"}],
+        "origin": "juthawong", "package_name": "ampareinvertcolor", "publisher": "Juthawong
+        Naisanguansee", "sections": [], "summary": "Simply Invert CSS Color - Made
+        For Web Designer", "title": "Ampare Invert CSS Color"}, {"apps": ["codium",
+        "url-handler"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/02/codium_blue_light.png",
+        "media": [{"height": 512, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/02/codium_blue_light.png",
+        "width": 512}, {"height": 688, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/02/Screenshot_from_2020-02-17_12-16-59.png",
+        "width": 1015}], "origin": "snapcrafters", "package_name": "codium", "publisher":
+        "Snapcrafters", "sections": [{"featured": false, "name": "development"}],
+        "summary": "Free/Libre Open Source Software Binaries of VSCode", "title":
+        "VS Codium"}, {"apps": ["exercism"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2019/10/icon_CMW6qDS.png",
+        "media": [{"height": 512, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/10/icon_CMW6qDS.png",
+        "width": 512}, {"height": 800, "type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/10/Screen_Shot_2019-10-07_at_10.24.59_PM.png",
+        "width": 2400}, {"height": 527, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/10/Screen_Shot_2019-10-07_at_10.20.38_PM.png",
+        "width": 992}], "origin": "exercism", "package_name": "exercism", "publisher":
+        "Exercism Team", "sections": [{"featured": false, "name": "development"},
+        {"featured": false, "name": "education"}], "summary": "Command-line client
+        for https://exercism.io", "title": "exercism"}, {"apps": ["audovia-classic"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/SongBuilderColourIcon256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/SongBuilderColourIcon256.png"},
+        {"height": 558, "type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/sm_Sydney_Opera_hero_q5OUBWt.png",
+        "width": 1674}, {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/Songs_2.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/Tree_2.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/Strings_2.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/Patterns_2.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/PatternComponents_3.png"}],
+        "origin": "songbuilder", "package_name": "audovia-classic", "publisher": "Donald
+        G Gray", "sections": [{"featured": false, "name": "music-and-audio"}], "summary":
+        "Database application for making music with JFugue MusicStrings", "title":
+        "Audovia Classic"}, {"apps": ["starship"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/Frame_4.1.png",
+        "media": [{"height": 640, "type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/Snap_Banner_1.png",
+        "width": 1920}, {"height": 348, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/Frame_4.1.png",
+        "width": 348}, {"height": 918, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/CleanShot_2019-12-11_at_22.30.382x.png",
+        "width": 1468}], "origin": "matankushner", "package_name": "starship", "publisher":
+        "Matan Kushner", "sections": [{"featured": false, "name": "development"}],
+        "summary": "The cross-shell prompt for astronauts", "title": "starship"},
+        {"apps": [], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/logo256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/logo256.png"}],
+        "origin": "starobinskii", "package_name": "ailibrary", "publisher": "Egor
+        Starobinskii", "sections": [{"featured": false, "name": "development"}], "summary":
+        "C++ Library from Ailurus Studio", "title": "AiLibrary"}, {"apps": ["client",
+        "inspect-cert", "wott-agent", "server", "ghostunnel", "verify-cert"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/wott-512.png",
+        "media": [{"height": 512, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/wott-512.png",
+        "width": 512}, {"height": 240, "type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/banner3_2lhCcnr.png",
+        "width": 720}], "origin": "vpetersson", "package_name": "wott-agent", "publisher":
+        "Viktor Petersson", "sections": [{"featured": false, "name": "security"},
+        {"featured": false, "name": "utilities"}], "summary": "Web of Trusted Things
+        Agent", "title": "wott-agent"}, {"apps": ["prosakart"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/icon_9JBNq23.png",
+        "media": [{"height": 50, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/11/icon_9JBNq23.png",
+        "width": 50}], "origin": "tuxbert", "package_name": "prosakart", "publisher":
+        "Elliot Paton-Simpson", "sections": [{"featured": false, "name": "education"}],
+        "summary": "Application for language memorization.", "title": "prosakart"},
+        {"apps": ["lonewolf"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/02/icon_3.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/02/icon_3.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/02/screenshot20150803_125313389.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/02/screenshot20150803_122107071_1.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/02/screenshot20150712_225009067_1.png"}],
+        "origin": "mterry", "package_name": "lonewolf", "publisher": "Michael Terry",
+        "sections": [{"featured": false, "name": "games"}], "summary": "A role-playing
+        choose-your-own-adventure game", "title": "Lone Wolf"}, {"apps": [], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/icon2.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/08/icon2.png"}],
+        "origin": "brunonova", "package_name": "tetris-in-racket", "publisher": "Bruno
+        Nova", "sections": [], "summary": "Tetris clone developed in Racket", "title":
+        "Tetris in Racket"}, {"apps": ["monexec"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/icon.svg_gJmASav.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/icon.svg_gJmASav.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/monexec-ui.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/monexec-ui.gif"}],
+        "origin": "reddec", "package_name": "monexec", "publisher": "Baryshnikov Aleksandr",
+        "sections": [{"featured": false, "name": "server-and-cloud"}, {"featured":
+        false, "name": "utilities"}], "summary": "Light supervisor with optional Consul
+        autoregistration", "title": "monexec"}, {"apps": ["inkdrop", "ipm"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/inkdrop-icon-google-play-store.png",
+        "media": [{"height": 512, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/12/inkdrop-icon-google-play-store.png",
+        "width": 512}, {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/desktop-dark-linux.png"}],
+        "origin": "craftzdog", "package_name": "inkdrop", "publisher": "Takuya Matsuyama",
+        "sections": [{"featured": false, "name": "productivity"}], "summary": "Note-taking
+        App with Robust Markdown Editor", "title": "Inkdrop"}, {"apps": ["ascii-patrol"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/aaaa.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/aaaa.png"},
+        {"height": 640, "type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/08/hdr.png",
+        "width": 1920}, {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/1F49012.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/16AFD09.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/16B361B.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/1D364EC.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/1D398AF.png"}],
+        "origin": "msokalski", "package_name": "ascii-patrol", "publisher": "\ud83d\ude37",
+        "sections": [{"featured": false, "name": "games"}], "summary": "Ascii Patrol",
+        "title": "Ascii Patrol"}, {"apps": ["otot"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/icon_copy_1.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/icon_copy_1.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/red_copy_1.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/blue_copy_1.png"}],
+        "origin": "tbmb", "package_name": "otot", "publisher": "Thomas Bille", "sections":
+        [], "summary": "!!!esrevinu pans eht fo pans tnatropmi tsom ehT!", "title":
+        "otot"}, {"apps": ["tmcbeans"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/icon_lzhGTdt.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/icon_lzhGTdt.png"},
+        {"height": 945, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/01/Screenshot_from_2020-01-10_13-41-12.png",
+        "width": 1549}], "origin": "moocfi", "package_name": "tmcbeans", "publisher":
+        "MOOC.fi / University of Helsinki", "sections": [{"featured": false, "name":
+        "development"}, {"featured": false, "name": "education"}], "summary": "IDE
+        for students using Test My Code", "title": "tmcbeans"}, {"apps": ["git-dag",
+        "git-cola-folder-handler", "git-cola"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/06/icon_A7VcT8y.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/06/icon_A7VcT8y.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/06/view-main-amending.png"}],
+        "origin": "brlin", "package_name": "git-cola-brlin", "publisher": "\u6797\u535a\u4ec1(Buo-ren,
+        Lin)", "sections": [], "summary": "The highly caffeinated Git GUI", "title":
+        "git-cola-brlin"}, {"apps": ["lepton"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/icon_i1tlvPA.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/icon_i1tlvPA.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/lepton-dark.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/07/stay_organized.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/jupyterNotebook_0QZ68yv.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/search_bar_S9tD3x1.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/edit.png"}],
+        "origin": "cosmo.lepton", "package_name": "lepton", "publisher": "Cosmo@Lepton",
+        "sections": [{"featured": false, "name": "development"}], "summary": "Free
+        & Open-source Code Snippet Manager", "title": "Lepton"}, {"apps": ["wickrme"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/WickrMe.jpg.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/WickrMe.jpg.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/01/desktop-wickrme.jpg"}],
+        "origin": "tleavy", "package_name": "wickrme", "publisher": "Wickr Inc", "sections":
+        [{"featured": false, "name": "security"}, {"featured": false, "name": "social"}],
+        "summary": "E2E Encrypted Anonymous Messaging", "title": "Wickr Me - Private
+        Messenger"}, {"apps": ["pall"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/icon_pQdODw4.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/icon_pQdODw4.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/pall_screen_1.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/pall_screen_23.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/pall_screen_3.png"}],
+        "origin": "dandansoysauce", "package_name": "pall", "publisher": "Dani Ona",
+        "sections": [{"featured": false, "name": "utilities"}], "summary": "Pick a
+        color. Anywhere.", "title": "Pall - Color Picker"}, {"apps": ["snipes"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/snipes.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/snipes.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/Screenshot_20190221_095127.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/Screenshot_20190221_095148.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/Screenshot_20190221_095250.png"}],
+        "origin": "popey", "package_name": "snipes", "publisher": "Alan Pope", "sections":
+        [{"featured": false, "name": "games"}], "summary": "Snipes", "title": "Snipes"},
+        {"apps": ["tx", "qt", "test", "testqt", "daemon-regtest", "cli", "daemon-testnet",
+        "cli-testnet", "qt-regtest", "cli-regtest", "daemon", "qt-testnet"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/icon.svg_8CWDJkq.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/icon.svg_8CWDJkq.png"}],
+        "origin": "ckti", "package_name": "ckti-snap-ion", "publisher": "CkTI", "sections":
+        [], "summary": "gaming related peer-to-peer network based digital currency",
+        "title": "ckti-snap-ion"}, {"apps": ["cli-testnet", "daemon", "cli", "daemon-regtest",
+        "qt-testnet", "qt-regtest", "daemon-testnet", "test", "qt", "tx", "cli-regtest"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/icon.svg_Pt7QaSa.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/icon.svg_Pt7QaSa.png"}],
+        "origin": "ckti", "package_name": "ckti-ioncore-current", "publisher": "CkTI",
+        "sections": [], "summary": "gaming related peer-to-peer network based digital
+        currency", "title": "ckti-ioncore-current"}, {"apps": ["magicmirror"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/icon_EySQanJ.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/icon_EySQanJ.png"}],
+        "origin": "ogra", "package_name": "magicmirror", "publisher": "Oliver Grawert",
+        "sections": [], "summary": "The open source modular smart mirror platform",
+        "title": "magicmirror"}, {"apps": ["tidy"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/icon_BMXppiT.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/icon_BMXppiT.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/tidy-help-heading_SdTttrY.png"}],
+        "origin": "brlin", "package_name": "tidy", "publisher": "\u6797\u535a\u4ec1(Buo-ren,
+        Lin)", "sections": [], "summary": "HTML parser and pretty printer.  The grand
+        daddy of HTML tools", "title": "Tidy (Unofficial Snap)"}, {"apps": ["corsixth"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/04/corsixth.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/04/corsixth.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/04/687474703a2f2f692e696d6775722e636f6d2f714856363055692e706e67.png"}],
+        "origin": "snapcrafters", "package_name": "corsixth", "publisher": "Snapcrafters",
+        "sections": [{"featured": false, "name": "games"}], "summary": "Open source
+        clone of Theme Hospital", "title": "CorsixTH"}, {"apps": ["sololearn"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/index.jpeg.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/04/index.jpeg.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/Screenshot_at_2018-09-24_14-44-39.png"}],
+        "origin": "apolitech", "package_name": "sololearn", "publisher": "APoliTech",
+        "sections": [{"featured": false, "name": "education"}], "summary": "A fast
+        and clean way to use SoloLearn", "title": "Sololearn"}, {"apps": ["firecamp"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/Firecap_logo_512x512.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/Firecap_logo_512x512.png"},
+        {"height": 800, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/10/FC-Home.png",
+        "width": 1280}, {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/FC-GraphQL.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/FC-SocketClient.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/FC-WebSocketClient.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/FC-Converter.png"}],
+        "origin": "nishchit14", "package_name": "firecamp", "publisher": "Firecamp",
+        "sections": [{"featured": false, "name": "development"}, {"featured": false,
+        "name": "productivity"}], "summary": "Protocol Agnostic API Studio", "title":
+        "Firecamp"}, {"apps": ["commonecho", "commonls", "userecho", "qtencodegui",
+        "pwd", "ls", "test", "find"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/NG2.png", "media":
+        [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/NG2.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/Screenshot_from_2018-09-28_11-41-16.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/Screenshot_from_2018-09-28_11-41-53.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/Screenshot_from_2018-09-28_11-42-10.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/09/Screenshot_from_2018-09-28_11-50-17.png"}],
+        "origin": "seefar", "package_name": "qtencodegui", "publisher": "Caleb Farrand",
+        "sections": [], "summary": "NGC Gui Test Launch", "title": "qtencodegui"},
+        {"apps": ["mosaic"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/mosaic.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/mosaic.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/Screenshot_from_2018-05-02_19-36-34.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/Screenshot_from_2018-05-02_20-08-59.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/05/Screenshot_from_2018-05-02_20-09-20.png"}],
+        "origin": "snapcrafters", "package_name": "mosaic", "publisher": "Snapcrafters",
+        "sections": [], "summary": "NCSA Mosaic", "title": "NCSA Mosaic"}, {"apps":
+        ["jami", "dring"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/08/icon_GV6o2t4.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/08/icon_GV6o2t4.png"}],
+        "origin": "diddledan", "package_name": "jami", "publisher": "Daniel Llewellyn",
+        "sections": [{"featured": false, "name": "social"}], "summary": "Jami, formally
+        Ring: secure, distributed communication software & SIP client", "title": "Jami"},
+        {"apps": ["codespell"], "developer_validation": "unproven", "icon_url": "",
+        "media": [], "origin": "snapcrafters", "package_name": "codespell", "publisher":
+        "Snapcrafters", "sections": [], "summary": "Check code for common misspellings.",
+        "title": "codespell"}, {"apps": [], "developer_validation": "unproven", "icon_url":
+        "", "media": [], "origin": "didrocks", "package_name": "snap-codelabs", "publisher":
+        "Didier Roche", "sections": [], "summary": "Ubuntu codelabs offline website
+        for using and creating snaps.", "title": "snap-codelabs"}, {"apps": ["codetree"],
+        "developer_validation": "unproven", "icon_url": "", "media": [], "origin":
+        "axino", "package_name": "codetree", "publisher": "Junien Fridrick", "sections":
+        [], "summary": "A code tree builder", "title": "codetree"}, {"apps": ["qrq"],
+        "developer_validation": "unproven", "icon_url": "", "media": [], "origin":
+        "bh1scw", "package_name": "qrq", "publisher": "FJKong", "sections": [], "summary":
+        "QRQ - yet another CW trainer (Linux, Unix, OS X, Windows)", "title": "qrq"},
+        {"apps": ["world"], "developer_validation": "unproven", "icon_url": "", "media":
+        [], "origin": "barry", "package_name": "world", "publisher": "Barry Warsaw",
+        "sections": [], "summary": "Where in the world is...?", "title": "world"},
+        {"apps": ["widl-nan"], "developer_validation": "unproven", "icon_url": "",
+        "media": [], "origin": "test22222", "package_name": "widl-nan", "publisher":
+        "Halton Huo", "sections": [], "summary": "Auto generate native C++ addon source
+        code by parsing Web IDL definition", "title": "widl-nan"}, {"apps": ["rpiboot"],
+        "developer_validation": "unproven", "icon_url": "", "media": [], "origin":
+        "pwlars", "package_name": "rpiboot", "publisher": "Paul Larson", "sections":
+        [], "summary": "Raspberry Pi USB booting code", "title": "rpiboot"}, {"apps":
+        ["gertty"], "developer_validation": "unproven", "icon_url": "", "media": [],
+        "origin": "craige", "package_name": "craige-gertty", "publisher": "Craige
+        McWhirter", "sections": [], "summary": "Console interface to Gerrit Code Review",
+        "title": "craige-gertty"}, {"apps": ["claat"], "developer_validation": "unproven",
+        "icon_url": "", "media": [], "origin": "simosx", "package_name": "claat",
+        "publisher": "Simos Xenitellis", "sections": [], "summary": "Codelabs command
+        line tool", "title": "claat"}, {"apps": ["ldc-build-runtime", "ldc-profdata",
+        "ldc2", "ldmd2", "ldc-prune-cache"], "developer_validation": "unproven", "icon_url":
+        "", "media": [], "origin": "ldc", "package_name": "ldc2", "publisher": "LDC
+        Snap Packages", "sections": [], "summary": "D compiler with LLVM backend",
+        "title": "ldc2"}, {"apps": ["synthesijer"], "developer_validation": "unproven",
+        "icon_url": "", "media": [], "origin": "miyox", "package_name": "synthesijer",
+        "publisher": "Takefumi MIYOSHI", "sections": [{"featured": false, "name":
+        "development"}, {"featured": false, "name": "devices-and-iot"}], "summary":
+        "Synthesijer is a compiler from Java to VHDL/Verilog HDL", "title": "Synthesijer
+        - A Java-based HLS compiler"}, {"apps": ["zfec", "zunfec"], "developer_validation":
+        "unproven", "icon_url": "", "media": [], "origin": "cmars", "package_name":
+        "zfec", "publisher": "Casey Marshall", "sections": [], "summary": "an efficient,
+        portable erasure coding tool", "title": "zfec"}, {"apps": ["aec-arm"], "developer_validation":
+        "unproven", "icon_url": "", "media": [], "origin": "svradityareddy", "package_name":
+        "aec-arm", "publisher": "Seelapureddy Venkata Rama Aditya Reddy", "sections":
+        [], "summary": "converts expression to arm cortex M4 instruction code", "title":
+        "aec-arm"}, {"apps": ["pspad"], "developer_validation": "unproven", "icon_url":
+        "", "media": [{"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/screenshot_d6XpWxC.png"}],
+        "origin": "mmtrt", "package_name": "pspad", "publisher": "Taqi Raza", "sections":
+        [{"featured": false, "name": "development"}, {"featured": false, "name": "utilities"}],
+        "summary": "PSPad is a text editor for developers.", "title": "PSPad (WINE)"},
+        {"apps": ["retdec"], "developer_validation": "unproven", "icon_url": "", "media":
+        [], "origin": "dragan-s", "package_name": "retdec", "publisher": "Dragan Stancevic",
+        "sections": [], "summary": "RetDec", "title": "retdec"}, {"apps": ["unixhttpc",
+        "unixhttpd"], "developer_validation": "unproven", "icon_url": "", "media":
+        [], "origin": "teknoraver", "package_name": "unixhttp", "publisher": "Matteo
+        Croce", "sections": [], "summary": "HTTP over Unix", "title": "unixhttp"},
+        {"apps": ["dot", "msh", "cfd", "geo", "sol", "def"], "developer_validation":
+        "unproven", "icon_url": "", "media": [], "origin": "snapcrafters", "package_name":
+        "su2", "publisher": "Snapcrafters", "sections": [], "summary": "The Open-Source
+        CFD Code", "title": "su2"}, {"apps": ["swift-demangle", "repl-swift", "lldb-mi-4-0-0",
+        "swiftc", "swift", "swift-autolink-extract", "lldb-server", "lldb-server-4-0-0",
+        "swift-build-tool", "lldb-mi", "lldb", "swift-package", "swift-build", "lldb-argdumper",
+        "lldb-4-0-0", "swift-test"], "developer_validation": "unproven", "icon_url":
+        "", "media": [], "origin": "lf-araujo", "package_name": "swift-language",
+        "publisher": "luis.nando", "sections": [], "summary": "The Swift Programming
+        Language", "title": "swift-language"}, {"apps": ["lolcat-python"], "developer_validation":
+        "unproven", "icon_url": "", "media": [], "origin": "simosx", "package_name":
+        "lolcat-python", "publisher": "Simos Xenitellis", "sections": [], "summary":
+        "lolcat utility written in Python", "title": "lolcat-python"}, {"apps": ["keyrunner"],
+        "developer_validation": "unproven", "icon_url": "", "media": [{"type": "screenshot",
+        "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/10/keyrunner.png"}],
+        "origin": "keyrunner", "package_name": "keyrunner", "publisher": "Russ Adams",
+        "sections": [], "summary": "A simple block puzzle/maze game", "title": "keyrunner"},
+        {"apps": ["virtualjaguar-jz"], "developer_validation": "unproven", "icon_url":
+        "", "media": [], "origin": "jz", "package_name": "virtualjaguar-jz", "publisher":
+        "Jacob Zimmermann", "sections": [], "summary": "Atari Jaguar emulator", "title":
+        "virtualjaguar-jz"}, {"apps": [], "developer_validation": "unproven", "icon_url":
+        "", "media": [], "origin": "ligboy", "package_name": "apktool", "publisher":
+        "ligboy", "sections": [], "summary": "A tool for reverse engineering 3rd party,
+        closed, binary Android apps.", "title": "apktool"}, {"apps": ["pt-cmars"],
+        "developer_validation": "unproven", "icon_url": "", "media": [], "origin":
+        "cmars", "package_name": "pt-cmars", "publisher": "Casey Marshall", "sections":
+        [], "summary": "The Platinum Searcher", "title": "pt-cmars"}, {"apps": ["owwatcher"],
+        "developer_validation": "unproven", "icon_url": "", "media": [], "origin":
+        "mikesalvatore", "package_name": "owwatcher", "publisher": "Mike Salvatore",
+        "sections": [{"featured": false, "name": "security"}, {"featured": false,
+        "name": "utilities"}], "summary": "Detects when world-writable files are created
+        in a specified directory", "title": "owwatcher"}, {"apps": ["roll"], "developer_validation":
+        "unproven", "icon_url": "", "media": [], "origin": "metasikander", "package_name":
+        "roll", "publisher": "Sikander", "sections": [{"featured": false, "name":
+        "games"}], "summary": "A python dice rolling application using standard dice
+        notation", "title": "roll"}, {"apps": ["qt", "daemon", "cli"], "developer_validation":
+        "unproven", "icon_url": "", "media": [], "origin": "h4rdm4n", "package_name":
+        "raven", "publisher": "H.", "sections": [], "summary": "Ravencoin - assets
+        made easy.", "title": "raven"}, {"apps": [], "developer_validation": "unproven",
+        "icon_url": "", "media": [], "origin": "thomi", "package_name": "gmailfilter",
+        "publisher": "Thomi Richards", "sections": [], "summary": "Programmatically
+        filter gmail messages", "title": "gmailfilter"}, {"apps": ["scrcpy", "adb"],
+        "developer_validation": "unproven", "icon_url": "", "media": [{"type": "screenshot",
+        "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/new.jpg"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/scrcpy-linux-ubuntu_ocuvkxS.png"}],
+        "origin": "sisco311", "package_name": "scrcpy", "publisher": "sisco311", "sections":
+        [{"featured": false, "name": "photo-and-video"}, {"featured": false, "name":
+        "utilities"}], "summary": "Display and control your Android device", "title":
+        "scrcpy"}, {"apps": ["pinano"], "developer_validation": "unproven", "icon_url":
+        "", "media": [], "origin": "vbota", "package_name": "pinano", "publisher":
+        "V Bota", "sections": [], "summary": "GNU nano text editor", "title": "pinano"},
+        {"apps": ["tic80"], "developer_validation": "unproven", "icon_url": "", "media":
+        [], "origin": "typicalncoder", "package_name": "tic80", "publisher": "Sturov
+        Fedor", "sections": [], "summary": "TIC-80 is a fantasy computer for making,
+        playing and sharing tiny games.", "title": "tic80"}, {"apps": ["clangd"],
+        "developer_validation": "unproven", "icon_url": "", "media": [], "origin":
+        "3v1n0", "package_name": "clangd", "publisher": "Marco Trevisan (Trevi\u00f1o)",
+        "sections": [], "summary": "Language Server Protocol implementation for C/C++
+        IDEs", "title": "clangd"}, {"apps": ["ipetoipe", "pdflatex", "ipeextract",
+        "ipe", "kpsewhich", "iperender", "ipe6upgrade", "sh", "bibtex", "ipescript",
+        "lualatex"], "developer_validation": "unproven", "icon_url": "", "media":
+        [], "origin": "ipe", "package_name": "ipe", "publisher": "Otfried Cheong",
+        "sections": [], "summary": "An extensible drawing editor with Latex text",
+        "title": "Ipe"}, {"apps": [], "developer_validation": "unproven", "icon_url":
+        "", "media": [], "origin": "esnow", "package_name": "cpython-esnow", "publisher":
+        "Eric Snow", "sections": [], "summary": "CPython is the reference implementation
+        of the Python programming language.", "title": "cpython-esnow"}, {"apps":
+        ["gh"], "developer_validation": "unproven", "icon_url": "", "media": [{"height":
+        1640, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2020/02/73286699-9f922180-41bd-11ea-87c9-60a2d31fd0ac.png",
+        "width": 2524}], "origin": "casper-dcl", "package_name": "gh", "publisher":
+        "Casper", "sections": [{"featured": false, "name": "development"}], "summary":
+        "The GitHub CLI", "title": "gh"}, {"apps": ["censor", "lolcat-c"], "developer_validation":
+        "unproven", "icon_url": "", "media": [], "origin": "simosx", "package_name":
+        "lolcat-c", "publisher": "Simos Xenitellis", "sections": [], "summary": "lolcat
+        utility written in C", "title": "lolcat-c"}, {"apps": ["superperms"], "developer_validation":
+        "unproven", "icon_url": "", "media": [], "origin": "diddledan", "package_name":
+        "superperms", "publisher": "Daniel Llewellyn", "sections": [{"featured": false,
+        "name": "science"}], "summary": "Search for minimal Super Permutations", "title":
+        "superperms"}, {"apps": ["lolcat-rust"], "developer_validation": "unproven",
+        "icon_url": "", "media": [], "origin": "simosx", "package_name": "lolcat-rust",
+        "publisher": "Simos Xenitellis", "sections": [], "summary": "lolcat utility
+        written in Rust", "title": "lolcat-rust"}, {"apps": ["usb-devices", "lsusb"],
+        "developer_validation": "unproven", "icon_url": "", "media": [], "origin":
+        "teknoraver", "package_name": "usb-utils", "publisher": "Matteo Croce", "sections":
+        [], "summary": "Linux USB utilities", "title": "usb-utils"}, {"apps": ["toolbox"],
+        "developer_validation": "unproven", "icon_url": "", "media": [], "origin":
+        "axw", "package_name": "tlaplus", "publisher": "Andrew Wilkins", "sections":
+        [], "summary": "The TLA Toolbox is an IDE for the TLA+ tools.", "title": "tlaplus"},
+        {"apps": ["codav"], "developer_validation": "unproven", "icon_url": "", "media":
+        [{"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/02/codav.png"}],
+        "origin": "cimm", "package_name": "codav", "publisher": "Simon", "sections":
+        [{"featured": false, "name": "finance"}], "summary": "Reads CODA SEPA payment
+        XML files", "title": "CODAv"}, {"apps": ["lolcat-go"], "developer_validation":
+        "unproven", "icon_url": "", "media": [], "origin": "simosx", "package_name":
+        "lolcat-go", "publisher": "Simos Xenitellis", "sections": [], "summary": "lolcat
+        utility written in golang", "title": "lolcat-go"}, {"apps": ["vale"], "developer_validation":
+        "unproven", "icon_url": "", "media": [{"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/39656657-59e62c26-4fb6-11e8-9f48-ba230400ed55.png"}],
+        "origin": "jdkato", "package_name": "vale", "publisher": "Joseph Kato", "sections":
+        [], "summary": "A customizable, syntax-aware linter for prose.", "title":
+        "Vale"}, {"apps": ["hightail"], "developer_validation": "unproven", "icon_url":
+        "", "media": [], "origin": "dj3500", "package_name": "hightail", "publisher":
+        "dj3500", "sections": [], "summary": "Automatic tester for programming contests",
+        "title": "hightail"}, {"apps": ["swift-demangle", "repl-swift", "lldb-mi-4-0-0",
+        "swiftc", "swift", "swift-autolink-extract", "lldb-server", "lldb-server-4-0-0",
+        "swift-build-tool", "lldb-mi", "lldb", "swift-package", "swift-build", "lldb-argdumper",
+        "lldb-4-0-0", "swift-test"], "developer_validation": "unproven", "icon_url":
+        "", "media": [], "origin": "lf-araujo", "package_name": "swift-lf-araujo",
+        "publisher": "luis.nando", "sections": [], "summary": "The Swift Programming
+        Language", "title": "swift-lf-araujo"}, {"apps": ["unifi-backup"], "developer_validation":
+        "unproven", "icon_url": "", "media": [], "origin": "moon127", "package_name":
+        "unifi-backup-moon127", "publisher": "Gareth Woolridge", "sections": [], "summary":
+        "Backup script for Ubiquiti UniFi controller", "title": "unifi-backup-moon127"},
+        {"apps": ["swift-demangle", "repl-swift", "lldb-mi-4-0-0", "swiftc", "swift",
+        "swift-autolink-extract", "lldb-server", "lldb-server-4-0-0", "swift-build-tool",
+        "lldb-mi", "lldb", "swift-package", "swift-build", "lldb-argdumper", "lldb-4-0-0",
+        "swift-test"], "developer_validation": "unproven", "icon_url": "", "media":
+        [], "origin": "nixberg", "package_name": "swift", "publisher": "Konstantin
+        Schneeberger", "sections": [], "summary": "The Swift Programming Language",
+        "title": "swift"}, {"apps": [], "developer_validation": "unproven", "icon_url":
+        "", "media": [], "origin": "nsg", "package_name": "homer-nsg", "publisher":
+        "Stefan Berggren", "sections": [], "summary": "nsg''s Home Automation API/System",
+        "title": "homer-nsg"}, {"apps": ["open-adventure"], "developer_validation":
+        "unproven", "icon_url": "", "media": [], "origin": "mkg20001", "package_name":
+        "open-adventure", "publisher": "Maciej Kr\u00fcger", "sections": [], "summary":
+        "Forward-port of the Crowther/Woods Adventure 2.5 from 1995", "title": "open-adventure"},
+        {"apps": ["env-get", "config-get", "config-set", "createtables"], "developer_validation":
+        "unproven", "icon_url": "", "media": [], "origin": "codersquid", "package_name":
+        "submission-service", "publisher": "Sheila Miguez", "sections": [], "summary":
+        "Submission Service for accepting Checkbox results", "title": "submission-service"},
+        {"apps": ["pycdas", "pycdc"], "developer_validation": "unproven", "icon_url":
+        "", "media": [], "origin": "khiemdoan", "package_name": "pycdc", "publisher":
+        "Khiem Doan", "sections": [], "summary": "A Python Byte-code Disassembler/Decompiler",
+        "title": "pycdc"}, {"apps": ["cfcreminder"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/Icon_ZLipVS9.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/Icon_ZLipVS9.png"}],
+        "origin": "moeentm", "package_name": "cfcreminder", "publisher": "Moeen Farhadi",
+        "sections": [{"featured": false, "name": "education"}], "summary": "Indicator
+        Codeforces Reminder", "title": "Codeforces Reminder"}, {"apps": ["bin2src"],
+        "developer_validation": "unproven", "icon_url": "", "media": [], "origin":
+        "tim-clicks", "package_name": "bin2src", "publisher": "Tim McNamara", "sections":
+        [{"featured": false, "name": "development"}, {"featured": false, "name": "utilities"}],
+        "summary": "Convert bytes to source code", "title": "bin2src"}, {"apps": ["black"],
+        "developer_validation": "unproven", "icon_url": "", "media": [], "origin":
+        "sergiusens", "package_name": "black", "publisher": "Sergio Schvezov", "sections":
+        [], "summary": "The uncompromising Python code formatter", "title": "black"},
+        {"apps": ["black"], "developer_validation": "unproven", "icon_url": "", "media":
+        [], "origin": "stub", "package_name": "black-canonical-is", "publisher": "Stuart
+        Bishop", "sections": [], "summary": "The uncompromising Python code formatter",
+        "title": "black-canonical-is"}, {"apps": ["dfmt"], "developer_validation":
+        "unproven", "icon_url": "", "media": [], "origin": "dlang", "package_name":
+        "dfmt", "publisher": "D Programming Language", "sections": [{"featured": false,
+        "name": "development"}], "summary": "Code formatter for the D programming
+        language", "title": "dfmt"}, {"apps": ["crystal", "shards"], "developer_validation":
+        "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/B_Crystal_icon_copy.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/B_Crystal_icon_copy.png"},
+        {"type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/banner-featured_FZOuZl9.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/screen1_ABjnNHM.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/screen2_hNvKUQP.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/banner.png"}],
+        "origin": "crystal-lang", "package_name": "crystal", "publisher": "Crystal
+        Language", "sections": [{"featured": false, "name": "development"}], "summary":
+        "A language for humans and computers", "title": "Crystal"}, {"apps": ["pyresistors"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/pyresistors-256.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/pyresistors-256.png"}],
+        "origin": "g-christ", "package_name": "pyresistors", "publisher": "G\u00f6tz
+        Christ", "sections": [{"featured": false, "name": "education"}, {"featured":
+        false, "name": "science"}], "summary": "Calculate electrical resistors value
+        and tolerance by their color codes", "title": "pyresistors"}, {"apps": ["dfix"],
+        "developer_validation": "unproven", "icon_url": "", "media": [], "origin":
+        "dlang", "package_name": "dfix", "publisher": "D Programming Language", "sections":
+        [{"featured": false, "name": "development"}], "summary": "Developer tool to
+        auto-upgrade D source code", "title": "dfix"}, {"apps": ["nemu"], "developer_validation":
+        "unproven", "icon_url": "", "media": [], "origin": "powersj", "package_name":
+        "nemu", "publisher": "Joshua Powers", "sections": [{"featured": false, "name":
+        "development"}, {"featured": false, "name": "server-and-cloud"}], "summary":
+        "Stripped down fork of QEMU by Intel", "title": "nemu"}, {"apps": ["tarp"],
+        "developer_validation": "unproven", "icon_url": "", "media": [], "origin":
+        "bevanhunt", "package_name": "tarp", "publisher": "Bevan Hunt", "sections":
+        [], "summary": "Rust Code Coverage Reporter", "title": "tarp"}, {"apps": ["dscanner"],
+        "developer_validation": "unproven", "icon_url": "", "media": [], "origin":
+        "dlang", "package_name": "dscanner", "publisher": "D Programming Language",
+        "sections": [{"featured": false, "name": "development"}], "summary": "Developer
+        tool for analyzing D source code", "title": "dscanner"}, {"apps": ["transporter"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/com.github.bleakgrey.transporter.svg.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/02/com.github.bleakgrey.transporter.svg.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/screenshot_aBMoPdP.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/screenshot2_U9BwRnT.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/03/screenshot3_JkTCCZG.png"}],
+        "origin": "ken-vandine", "package_name": "transporter", "publisher": "Ken
+        VanDine", "sections": [{"featured": false, "name": "social"}, {"featured":
+        false, "name": "utilities"}], "summary": "Hassle-free file sharing", "title":
+        "Transporter"}, {"apps": ["qr"], "developer_validation": "unproven", "icon_url":
+        "", "media": [], "origin": "suligap", "package_name": "suligap-python3-qrcode",
+        "publisher": "Przemys\u0142aw Suliga", "sections": [{"featured": false, "name":
+        "utilities"}], "summary": "Pure Python QR Code generator", "title": "suligap-python3-qrcode"},
+        {"apps": ["universal-ctags"], "developer_validation": "unproven", "icon_url":
+        "", "media": [], "origin": "tartley", "package_name": "universal-ctags", "publisher":
+        "Jonathan Hartley", "sections": [], "summary": "Parse source code to build
+        an index of defined symbols.", "title": "universal-ctags"}, {"apps": ["ccls"],
+        "developer_validation": "unproven", "icon_url": "", "media": [], "origin":
+        "alexmurray", "package_name": "ccls", "publisher": "Alex Murray", "sections":
+        [{"featured": false, "name": "development"}], "summary": "C/C++/ObjC Language
+        Server", "title": "ccls C/C++/ObjC Language Server"}, {"apps": ["bitcoinc-qt"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/BitcoinConfidential.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/BitcoinConfidential.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/Screenshot_from_2019-05-27_13-38-48.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/Screenshot_from_2019-05-27_13-38-59.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/Screenshot_from_2019-05-27_13-39-10.png"}],
+        "origin": "bitcoin-confidential", "package_name": "confidential-bitcoin",
+        "publisher": "Bitcoin Confidential", "sections": [{"featured": false, "name":
+        "finance"}, {"featured": false, "name": "utilities"}], "summary": "Bitcoin
+        Confidential", "title": "Bitcoin Confidential"}, {"apps": ["tsukushi"], "developer_validation":
+        "unproven", "icon_url": "", "media": [], "origin": "hiso-junichi2", "package_name":
+        "tsukushi", "publisher": "Junichi Suetsugu", "sections": [], "summary": "A
+        code editor created by Kivy.", "title": "tsukushi"}, {"apps": ["mu-editor"],
+        "developer_validation": "unproven", "icon_url": "", "media": [], "origin":
+        "bennuttall", "package_name": "mu-editor", "publisher": "Ben Nuttall", "sections":
+        [], "summary": "A simple Python code editor", "title": "mu-editor"}, {"apps":
+        ["url-handler", "vscodium"], "developer_validation": "unproven", "icon_url":
+        "", "media": [], "origin": "vscodium", "package_name": "vscodium", "publisher":
+        "VSCodium", "sections": [], "summary": "Code editing. Redefined.", "title":
+        "vscodium"}, {"apps": ["julia-docs", "julia"], "developer_validation": "verified",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/743164.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/743164.png"},
+        {"type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/julia-open-graph-3-1.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/Screen_Shot_2019-06-12_at_12.00.58_PM.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/Screen_Shot_2019-06-12_at_12.04.55_PM.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/Screen_Shot_2019-06-12_at_12.06.32_PM.png"}],
+        "origin": "julialang", "package_name": "julia", "publisher": "The Julia Language",
+        "sections": [{"featured": false, "name": "development"}, {"featured": false,
+        "name": "science"}], "summary": "The Julia programming language", "title":
+        "julia"}, {"apps": ["config", "status"], "developer_validation": "unproven",
+        "icon_url": "", "media": [], "origin": "ammp", "package_name": "ammp-wifi-ap",
+        "publisher": "Svet Bajlekov", "sections": [], "summary": "WiFi Access Point
+        based on hostapd - for AMMP Edge devices", "title": "ammp-wifi-ap"}, {"apps":
+        ["bash-language-server"], "developer_validation": "unproven", "icon_url":
+        "", "media": [], "origin": "alexmurray", "package_name": "bash-language-server",
+        "publisher": "Alex Murray", "sections": [{"featured": false, "name": "development"},
+        {"featured": false, "name": "utilities"}], "summary": "Bash Language Server",
+        "title": "Bash Language Server"}, {"apps": ["fluxctl"], "developer_validation":
+        "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/08/flux-icon2x.png",
+        "media": [{"height": 128, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/08/flux-icon2x.png",
+        "width": 128}], "origin": "weaveflux", "package_name": "fluxctl", "publisher":
+        "Flux CD developers", "sections": [{"featured": false, "name": "server-and-cloud"}],
+        "summary": "fluxctl talks to Flux and helps you deploy your code", "title":
+        "fluxctl"}, {"apps": [], "developer_validation": "unproven", "icon_url": "",
+        "media": [], "origin": "achauhan30", "package_name": "secure-coldchain-gps-app-sysgain-auto",
+        "publisher": "Aishwarye Chauhan", "sections": [], "summary": "Node JS code
+        for the Gateway", "title": "secure-coldchain-gps-app-sysgain-auto"}, {"apps":
+        ["notepad-plus-plus"], "developer_validation": "unproven", "icon_url": "",
+        "media": [], "origin": "minple", "package_name": "notepad-plus-plusminple",
+        "publisher": "minple", "sections": [], "summary": "notepad-plus-plus is a
+        free source code editor.", "title": "notepad-plus-plusminple"}, {"apps": ["rax2",
+        "rarun2", "r2pm", "r2agent", "ragg2", "rahash2", "rasm2", "rafind2", "rabin2",
+        "radare2", "radiff2"], "developer_validation": "unproven", "icon_url": "",
+        "media": [], "origin": "simosx", "package_name": "radare2-simosx", "publisher":
+        "Simos Xenitellis", "sections": [], "summary": "Radare2 reverse engineering
+        framework and tool", "title": "radare2-simosx"}, {"apps": [], "developer_validation":
+        "unproven", "icon_url": "", "media": [], "origin": "ondra", "package_name":
+        "opengrok-src-updater", "publisher": "Ondrej Kubik", "sections": [], "summary":
+        "source code sync configuration for opengrok", "title": "opengrok-src-updater"},
+        {"apps": [], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/com.asus.webview.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/07/com.asus.webview.png"}],
+        "origin": "keshavnrj", "package_name": "webengine513", "publisher": "keshavbhatt",
+        "sections": [{"featured": false, "name": "development"}], "summary": "Qt 5.13.0
+        full Webengine stack with codecs support (content snap).", "title": "Qt Webengine
+        5.13"}, {"apps": ["leo-editor"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2019/08/SplashScreen_trans.png",
+        "media": [{"height": 278, "type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/08/SplashScreen_trans.png",
+        "width": 278}, {"height": 969, "type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/08/DarkScreenShot.png",
+        "width": 1152}], "origin": "technatica", "package_name": "leo-editor", "publisher":
+        "Chris George", "sections": [{"featured": false, "name": "development"}, {"featured":
+        false, "name": "productivity"}], "summary": "Leo is an IDE, outliner and PIM.",
+        "title": "Leo Editor"}, {"apps": ["karuta"], "developer_validation": "unproven",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/wp_400x400.jpg.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/wp_400x400.jpg.png"}],
+        "origin": "nekoaddict", "package_name": "karuta", "publisher": "Yusuke Tabata",
+        "sections": [{"featured": false, "name": "development"}, {"featured": false,
+        "name": "devices-and-iot"}], "summary": "Karuta is a scripting language for
+        FPGA design (so called HLS).", "title": "Karuta HLS Compiler"}, {"apps": ["drepl"],
+        "developer_validation": "unproven", "icon_url": "", "media": [], "origin":
+        "dlang", "package_name": "drepl", "publisher": "D Programming Language", "sections":
+        [], "summary": "A REPL for D", "title": "drepl"}, {"apps": ["emacs", "ctags",
+        "ebrowse", "etags", "emacsclient"], "developer_validation": "unproven", "icon_url":
+        "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/emacs_2c1XSzj.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/emacs_2c1XSzj.png"},
+        {"type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/emacs-banner.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/Screenshot_from_2019-05-19_20-35-30.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/Screenshot_from_2019-05-21_14-43-04.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/Screenshot_from_2019-05-21_14-46-15.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/Screenshot_from_2019-05-21_14-46-59.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/Screenshot_from_2019-05-21_14-42-12.png"}],
+        "origin": "alexmurray", "package_name": "emacs", "publisher": "Alex Murray",
+        "sections": [{"featured": false, "name": "development"}, {"featured": false,
+        "name": "productivity"}], "summary": "GNU Emacs is the extensible self-documenting
+        text editor", "title": "GNU Emacs"}, {"apps": ["rx", "tx"], "developer_validation":
+        "unproven", "icon_url": "", "media": [], "origin": "techtonik", "package_name":
+        "trx-audio", "publisher": "anatoly techtonik", "sections": [{"featured": false,
+        "name": "devices-and-iot"}, {"featured": false, "name": "music-and-audio"}],
+        "summary": "trx: Realtime audio over IP", "title": "trx-audio"}, {"apps":
+        ["lyricpad"], "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/icon_t8a6AJW.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/icon_t8a6AJW.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/sc1.jpeg"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/sc2.jpeg"}],
+        "origin": "keshavnrj", "package_name": "lyricpad", "publisher": "keshavbhatt",
+        "sections": [{"featured": false, "name": "music-and-audio"}, {"featured":
+        false, "name": "utilities"}], "summary": "Powerful lyrics search app", "title":
+        "LyricPad"}, {"apps": ["ipython", "jupyter", "nbconvert"], "developer_validation":
+        "verified", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/Jupyter_logo.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/Jupyter_logo.png"},
+        {"type": "banner", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/06/jupyter-banner.png"}],
+        "origin": "projectjupyter", "package_name": "jupyter", "publisher": "Jupyter
+        Project", "sections": [{"featured": false, "name": "development"}, {"featured":
+        false, "name": "science"}], "summary": "Jupyter metapackage. Install all the
+        Jupyter components in one go.", "title": "Project Jupyter"}, {"apps": ["pymol"],
+        "developer_validation": "unproven", "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/icon.svg_InfvH3P.png",
+        "media": [{"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/icon.svg_InfvH3P.png"},
+        {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/05/Bildschirmfoto_vom_2019-05-15_15-26-46.png"}],
+        "origin": "glasen", "package_name": "pymol-oss", "publisher": "Stefan Glasenhardt",
+        "sections": [{"featured": false, "name": "education"}, {"featured": false,
+        "name": "science"}], "summary": "PyMOL is a molecular visualization system.",
+        "title": "pymol-oss"}, {"apps": ["daemon", "cli", "tx", "qt"], "developer_validation":
+        "unproven", "icon_url": "", "media": [], "origin": "ionomy", "package_name":
+        "ioncoin-ce", "publisher": "dev", "sections": [{"featured": false, "name":
+        "finance"}], "summary": "gaming related peer-to-peer network based digital
+        currency", "title": "ioncoin-ce"}]}, "_links": {"last": {"href": "https://api.snapcraft.io/api/v1/snaps/search?q=code&size=300&page=2&scope=wide&confinement=strict%2Cclassic&fields=package_name%2Ctitle%2Csummary%2Cicon_url%2Cmedia%2Cpublisher%2Cdeveloper_validation%2Corigin%2Capps%2Csections&arch=wide"},
+        "next": {"href": "https://api.snapcraft.io/api/v1/snaps/search?q=code&size=300&page=2&scope=wide&confinement=strict%2Cclassic&fields=package_name%2Ctitle%2Csummary%2Cicon_url%2Cmedia%2Cpublisher%2Cdeveloper_validation%2Corigin%2Capps%2Csections&arch=wide"},
+        "self": {"href": "https://api.snapcraft.io/api/v1/snaps/search?q=code&size=300&page=1&scope=wide&confinement=strict%2Cclassic&fields=package_name%2Ctitle%2Csummary%2Cicon_url%2Cmedia%2Cpublisher%2Cdeveloper_validation%2Corigin%2Capps%2Csections&arch=wide"}},
+        "total": 287}'
+    headers:
+      Content-Length:
+      - '155391'
+      Content-Type:
+      - application/hal+json
+      Date:
+      - Wed, 19 Feb 2020 13:20:49 GMT
+      Server:
+      - gunicorn/19.7.1
+      Snap-Store-Version:
+      - '18'
+      Vary:
+      - X-Ubuntu-Store, X-Ubuntu-Series, X-Ubuntu-Architecture
+      Via:
+      - 1.1 juju-7794b8-prod-ols-snap-store-indep-1656 (squid/3.5.27)
+      X-Cache:
+      - MISS from juju-7794b8-prod-ols-snap-store-indep-1656
+      X-Cache-Lookup:
+      - MISS from juju-7794b8-prod-ols-snap-store-indep-1656:3128
+      X-Request-Id:
+      - 0AACC05AADEE0A325C8501BB5E4D362C37D0879
+      X-VCS-Revision:
+      - 3476d7a
+      X-View-Name:
+      - snapdevicegw.webapi_search.snap_search
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_snapcraft_store_api.py
+++ b/tests/test_snapcraft_store_api.py
@@ -8,6 +8,46 @@ class SnapcraftApiTest(VCRTestCase):
         self.client = SnapcraftStoreApi()
         return super(SnapcraftApiTest, self).setUp()
 
+    def test_search_size(self):
+        """
+        Check we can specify the number of search results
+        """
+
+        result_default = self.client.search("code")
+        result_10 = self.client.search("code", size=10)
+        result_100 = self.client.search("code", size=100)
+        result_300 = self.client.search("code", size=300)
+
+        self.assertEqual(result_default["total"], 287)
+        self.assertEqual(result_10["total"], 287)
+        self.assertEqual(result_100["total"], 287)
+        self.assertEqual(result_300["total"], 287)
+
+        snaps_default = result_default["_embedded"]["clickindex:package"]
+        snaps_10 = result_10["_embedded"]["clickindex:package"]
+        snaps_100 = result_100["_embedded"]["clickindex:package"]
+        snaps_300 = result_300["_embedded"]["clickindex:package"]
+
+        self.assertEqual(len(snaps_default), 100)
+        self.assertEqual(len(snaps_10), 10)
+        self.assertEqual(len(snaps_100), 100)
+        self.assertEqual(len(snaps_300), 250)
+
+    def test_search_by_arch(self):
+        """
+        Check we can search for snaps and filter by architecture
+        """
+
+        result_default = self.client.search("toto", 10, 1)
+        result_amd64 = self.client.search("toto", 10, 1, arch="amd64")
+        result_wide = self.client.search("toto", 10, 1, arch="wide")
+        result_i386 = self.client.search("toto", 10, 1, arch="i386")
+
+        self.assertEqual(result_amd64["total"], 6)
+        self.assertEqual(result_default["total"], 7)
+        self.assertEqual(result_wide["total"], 7)
+        self.assertEqual(result_i386["total"], 3)
+
     def test_get_all_items(self):
         result = self.client.get_all_items(size=16, api_version=1)
         snaps = result["_embedded"]["clickindex:package"]


### PR DESCRIPTION
Arch behaves a bit oddly, but these two together should cover all bases. That is: "X-Ubuntu-Architecture" header will be used if present, and "arch" will be ignored *unless* "arch" == "wide".
"wide" doesn't work in "X-Ubuntu-Architecture", but it doesn't matter because if "arch" == "wide" then "X-Ubuntu-Architecture" is ignored and all architectures are returned.

See: https://api.snapcraft.io/docs/search.html#snap_search

QA
--


You can review this branch by reviewing https://github.com/canonical-web-and-design/ubuntu.com/pull/6696