### PR TITLE
Added env var support to change store URL

### DIFF
--- a/canonicalwebteam/store_api/stores/snapstore.py
+++ b/canonicalwebteam/store_api/stores/snapstore.py
@@ -1,6 +1,10 @@
+from os import getenv
+
 import requests
 
 from canonicalwebteam.store_api.store import Store
+
+SNAPSTORE_API_URL = getenv("SNAPSTORE_API_URL", "https://api.snapcraft.io/")
 
 
 class SnapStore(Store):
@@ -9,11 +13,11 @@ class SnapStore(Store):
 
         self.config = {
             1: {
-                "base_url": "https://api.snapcraft.io/api/v1/snaps/",
+                "base_url": f"{SNAPSTORE_API_URL}api/v1/snaps/",
                 "headers": {"X-Ubuntu-Series": "16"},
             },
             2: {
-                "base_url": "https://api.snapcraft.io/v2/snaps/",
+                "base_url": f"{SNAPSTORE_API_URL}v2/snaps/",
                 "headers": {"Snap-Device-Series": "16"},
             },
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'canonicalwebteam.store-api'
-version = '2.0.0'
+version = '2.0.1'
 description = ''
 authors = ['Canonical Web Team <webteam@canonical.com>']
 license = 'LGPL-3.0'


### PR DESCRIPTION
Added `SNAPSTORE_API_URL` to be able to change to URL to the API for the staging API.

Fixes #16 

# QA

Follow the QA steps here:
https://github.com/canonical-web-and-design/snapcraft.io/pull/2662