### PR TITLE
Fix Publisher URL API v2

### DIFF
--- a/canonicalwebteam/store_api/publisher.py
+++ b/canonicalwebteam/store_api/publisher.py
@@ -253,6 +253,7 @@ class Publisher:
     def snap_release_history(self, session, snap_name, page=1):
         response = self.session.get(
             url=self.get_endpoint_url(f"snaps/{snap_name}/releases", 2),
+            params={"page": page},
             headers=self._get_authorization_header(session),
         )
 

--- a/canonicalwebteam/store_api/stores/snapstore.py
+++ b/canonicalwebteam/store_api/stores/snapstore.py
@@ -64,5 +64,5 @@ class SnapPublisher(Publisher):
 
         self.config = {
             1: {"base_url": f"{SNAPSTORE_DASHBOARD_API_URL}dev/api/"},
-            2: {"base_url": f"{SNAPSTORE_API_URL}api/v2/"},
+            2: {"base_url": f"{SNAPSTORE_DASHBOARD_API_URL}api/v2/"},
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'canonicalwebteam.store-api'
-version = '2.1.0'
+version = '2.1.1'
 description = ''
 authors = ['Canonical Web Team <webteam@canonical.com>']
 license = 'LGPL-3.0'


### PR DESCRIPTION
- The base URL for the v2 API version is wrong
- Added missing page param to snap_release_history