### PR TITLE
Added publisher API for charms - List publisher charms

### DIFF
--- a/canonicalwebteam/store_api/stores/charmstore.py
+++ b/canonicalwebteam/store_api/stores/charmstore.py
@@ -3,8 +3,12 @@ from os import getenv
 import requests
 
 from canonicalwebteam.store_api.store import Store
+from canonicalwebteam.store_api.publisher import Publisher
 
-SNAPSTORE_API_URL = getenv("CHARMSTORE_API_URL", "https://api.snapcraft.io/")
+CHARMSTORE_API_URL = getenv("CHARMSTORE_API_URL", "https://api.snapcraft.io/")
+CHARMSTORE_PUBLISHER_API_URL = getenv(
+    "CHARMSTORE_PUBLISHER_API_URL", "https://api.snapcraft.io/"
+)
 
 
 class CharmStore(Store):
@@ -12,5 +16,37 @@ class CharmStore(Store):
         super().__init__(session, store)
 
         self.config = {
-            2: {"base_url": f"{SNAPSTORE_API_URL}v2/charms/"},
+            2: {"base_url": f"{CHARMSTORE_API_URL}v2/charms/"},
         }
+
+
+class CharmPublisher(Publisher):
+    def __init__(self, session=requests.Session()):
+        super().__init__(session)
+
+        self.config = {
+            1: {
+                "base_url": f"{CHARMSTORE_PUBLISHER_API_URL}publisher/api/v1/"
+            },
+        }
+
+    def _get_authorization_header(self, session):
+        return {"Cookie": session["publisher-macaroon"]}
+
+    def whoami(self, session):
+        headers = self._get_authorization_header(session)
+
+        response = self.session.get(
+            url=self.get_endpoint_url("whoami"), headers=headers
+        )
+
+        return self.process_response(response)
+
+    def get_account_packages(self, session):
+        headers = self._get_authorization_header(session)
+
+        response = self.session.get(
+            url=self.get_endpoint_url("charm"), headers=headers
+        )
+
+        return self.process_response(response)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'canonicalwebteam.store-api'
-version = '2.1.2'
+version = '2.2.0'
 description = ''
 authors = ['Canonical Web Team <webteam@canonical.com>']
 license = 'LGPL-3.0'

--- a/tests/cassettes/CharmPublisherTest.test_get_account_packages.yaml
+++ b/tests/cassettes/CharmPublisherTest.test_get_account_packages.yaml
@@ -1,0 +1,40 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.staging.snapcraft.io/publisher/api/v1/charm
+  response:
+    body:
+      string: '{"charms":[{"authority":null,"charm-id":"a6GFYhMtbwKHgtft5bJfUUMscY1Be2CF","contact":null,"description":null,"name":"fran-test","package-type":"charm","private":false,"publisher":{"display-name":null,"id":"mGOTZu7OjyCKQxEL7kO7JKkTrHiKDrne","username":null,"validation":"unproven"},"status":"registered","store":"ubuntu","summary":null,"title":null,"website":null}]}
+
+        '
+    headers:
+      Content-Length:
+      - '366'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Jun 2020 12:57:33 GMT
+      PublisherGW-Version:
+      - '1'
+      Server:
+      - gunicorn/19.7.1
+      X-Request-Id:
+      - 93941A71BB040A324F5701BB5EF49F3DF8D2
+      X-VCS-Revision:
+      - 01f8e99
+      X-View-Name:
+      - publishergw.webapi.list_registered_names
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/CharmPublisherTest.test_whoami.yaml
+++ b/tests/cassettes/CharmPublisherTest.test_whoami.yaml
@@ -1,0 +1,40 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.staging.snapcraft.io/publisher/api/v1/whoami
+  response:
+    body:
+      string: '{"display-name":"Francisco Jim\u00e9nez Cabrera","id":"mGOTZu7OjyCKQxEL7kO7JKkTrHiKDrne","username":"jkfran"}
+
+        '
+    headers:
+      Content-Length:
+      - '110'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Jun 2020 12:55:33 GMT
+      PublisherGW-Version:
+      - '1'
+      Server:
+      - gunicorn/19.7.1
+      X-Request-Id:
+      - 93941A71B9700A324F5701BB5EF49EC5F8C2
+      X-VCS-Revision:
+      - 01f8e99
+      X-View-Name:
+      - publishergw.webapi.whoami
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_charmhub_publisher_api.py
+++ b/tests/test_charmhub_publisher_api.py
@@ -1,0 +1,35 @@
+from os import getenv
+
+from vcr_unittest import VCRTestCase
+from canonicalwebteam.store_api.stores.charmstore import CharmPublisher
+
+session = {"publisher-macaroon": getenv("PUBLISHER_MACAROON", "secret")}
+
+
+class CharmPublisherTest(VCRTestCase):
+    def _get_vcr_kwargs(self):
+        """
+        This removes the authorization header
+        from VCR so we don't record auth parameters
+        """
+        return {"filter_headers": ["Authorization", "Cookie"]}
+
+    def setUp(self):
+        self.client = CharmPublisher()
+        return super().setUp()
+
+    def test_whoami(self):
+        """
+        Check whoami response
+        """
+        response = self.client.whoami(session)
+        self.assertEqual(response["username"], "jkfran")
+
+    def test_get_account_packages(self):
+        """
+        Check get_account_packages response
+        """
+        response = self.client.get_account_packages(session)
+        test_charm = response["charms"][0]
+        self.assertEqual(test_charm["name"], "fran-test")
+        self.assertEqual(test_charm["package-type"], "charm")


### PR DESCRIPTION
## Done

- Replace `SNAPSTORE_API_URL` for `CHARMSTORE_API_URL`
- Added `get_account_packages` and `whoami` methods for CharmPublisher

Fixes https://github.com/canonical-web-and-design/charmhub.io/issues/139

## QA

Ask me how to get the your macaroon.

```bash
python3 -m venv venv
source venv/bin/activate
pip3 install git+https://github.com/jkfran/canonicalwebteam.store-api.git@charmhub-publisher#egg=canonicalwebteam.store-api==2.2.0
pip3 install ipython3
ipython3
```
And then:
```python3
from canonicalwebteam.store_api.stores.charmstore import CharmPublisher
from requests import Session

session = Session()
publisher = CharmPublisher(session)
publisher.whoami({"publisher-macaroon": "ASK ME!!"})
```

You should get your username.