### PR TITLE
CharmHub authentication changes

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # We are using the staging API for now:
-      CHARMSTORE_PUBLISHER_API_URL: https://api.staging.snapcraft.io/
+      CHARMSTORE_PUBLISHER_API_URL: https://api.staging.charmhub.io/
     steps:
     - uses: actions/checkout@v1
     - uses: dschep/install-poetry-action@v1.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'canonicalwebteam.store-api'
-version = '2.2.0'
+version = '2.3.0'
 description = ''
 authors = ['Canonical Web Team <webteam@canonical.com>']
 license = 'LGPL-3.0'

--- a/tests/cassettes/CharmPublisherTest.test_get_account_packages.yaml
+++ b/tests/cassettes/CharmPublisherTest.test_get_account_packages.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://api.staging.snapcraft.io/publisher/api/v1/charm
+    uri: https://api.staging.charmhub.io/publisher/api/v1/charm
   response:
     body:
       string: '{"charms":[{"authority":null,"charm-id":"a6GFYhMtbwKHgtft5bJfUUMscY1Be2CF","contact":null,"description":null,"name":"fran-test","package-type":"charm","private":false,"publisher":{"display-name":null,"id":"mGOTZu7OjyCKQxEL7kO7JKkTrHiKDrne","username":null,"validation":"unproven"},"status":"registered","store":"ubuntu","summary":null,"title":null,"website":null}]}

--- a/tests/cassettes/CharmPublisherTest.test_get_macaroon.yaml
+++ b/tests/cassettes/CharmPublisherTest.test_get_macaroon.yaml
@@ -1,0 +1,46 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Bakery-Protocol-Version:
+      - '2'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.staging.charmhub.io/publisher/api/v1/tokens
+  response:
+    body:
+      string: '{"macaroon":"{\"c\": [{\"i\": \"time-before 2021-07-15T15:33:12.630288Z\"},
+        {\"i64\": \"AuWOi6ByBY_WtcjYxKSgZBeNanbYiL_wbAxUFCz5-lj8nOZtD3nR48YnIBdqrSY3NpsHes_nzyENe4KipSvVokTACYoOGJLYJlU1fdFIycWzE1FFjLSTPmxfEmQlnGzGk1RjqiKtMAYhYMqktcn2eQmXan1mZ6AIxRYJZGKhueByYC6aOZZ03BDFw3aUEf1GNkUs\",
+        \"v64\": \"FshZODRhX_u3LGvcJvBYnfV1NO4pbTcmMhF2EAnjWnPpXbwRmr1pWyWZHQ31CBIfwwvO4oyq5pJKNOj2YCxtkJLF6D2H3-mX\",
+        \"l\": \"https://api.staging.jujucharms.com/identity/\"}], \"i64\": \"AwoQygV7FRA5a5sYLab3R4ObvBIBMBoOCgVsb2dpbhIFbG9naW4\",
+        \"s64\": \"MpIbSNT45giizaFJZl2r-vwTNCH66ZGO-rF0NR6rbrc\", \"l\": \"api.staging.snapcraft.io\"}"}
+
+        '
+    headers:
+      Content-Length:
+      - '621'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jul 2020 15:33:12 GMT
+      PublisherGW-Version:
+      - '1'
+      Server:
+      - gunicorn/19.7.1
+      X-Request-Id:
+      - 4F93641C89540A324F3001BB5F0F21B80264
+      X-VCS-Revision:
+      - 45dc73d
+      X-View-Name:
+      - publishergw.webapi.get_macaroon
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/CharmPublisherTest.test_whoami.yaml
+++ b/tests/cassettes/CharmPublisherTest.test_whoami.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://api.staging.snapcraft.io/publisher/api/v1/whoami
+    uri: https://api.staging.charmhub.io/publisher/api/v1/whoami
   response:
     body:
       string: '{"display-name":"Francisco Jim\u00e9nez Cabrera","id":"mGOTZu7OjyCKQxEL7kO7JKkTrHiKDrne","username":"jkfran"}

--- a/tests/test_charmhub_publisher_api.py
+++ b/tests/test_charmhub_publisher_api.py
@@ -3,7 +3,7 @@ from os import getenv
 from vcr_unittest import VCRTestCase
 from canonicalwebteam.store_api.stores.charmstore import CharmPublisher
 
-session = {"publisher-macaroon": getenv("PUBLISHER_MACAROON", "secret")}
+publisher_auth = getenv("PUBLISHER_MACAROON", "secret")
 
 
 class CharmPublisherTest(VCRTestCase):
@@ -12,24 +12,28 @@ class CharmPublisherTest(VCRTestCase):
         This removes the authorization header
         from VCR so we don't record auth parameters
         """
-        return {"filter_headers": ["Authorization", "Cookie"]}
+        return {"filter_headers": ["Authorization", "Macaroons"]}
 
     def setUp(self):
         self.client = CharmPublisher()
         return super().setUp()
 
+    def test_get_macaroon(self):
+        macaroon = self.client.get_macaroon()
+        self.assertIsInstance(macaroon, str)
+
     def test_whoami(self):
         """
         Check whoami response
         """
-        response = self.client.whoami(session)
+        response = self.client.whoami(publisher_auth)
         self.assertEqual(response["username"], "jkfran")
 
     def test_get_account_packages(self):
         """
         Check get_account_packages response
         """
-        response = self.client.get_account_packages(session)
+        response = self.client.get_account_packages(publisher_auth)
         test_charm = response["charms"][0]
         self.assertEqual(test_charm["name"], "fran-test")
         self.assertEqual(test_charm["package-type"], "charm")


### PR DESCRIPTION
## Done
CharmHub Publisher changes:
- Changed authentication header from "Cookie" to "Macaroons"
- Added `get_macaroon` method
- Send `Bakery-Protocol-Version` header
- Update API URL to `https://api.charmhub.io/`

## QA

Check all the tests are passing
