### PR TITLE
Update get_categories to use v2 API

### DIFF
--- a/.github/workflows/api_tests.yaml
+++ b/.github/workflows/api_tests.yaml
@@ -10,10 +10,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    env:
-      # We are using the staging API for now:
-      CHARMSTORE_PUBLISHER_API_URL: https://api.staging.snapcraft.io/
-
     steps:
     - uses: actions/checkout@v1
     - uses: dschep/install-poetry-action@v1.2

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -31,10 +31,6 @@ jobs:
   test-coverage:
     runs-on: ubuntu-latest
 
-    env:
-      # We are using the staging API for now:
-      CHARMSTORE_PUBLISHER_API_URL: https://api.staging.snapcraft.io/
-
     steps:
     - uses: actions/checkout@v1
     - uses: dschep/install-poetry-action@v1.2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,9 +35,6 @@ jobs:
 
   test-python:
     runs-on: ubuntu-latest
-    env:
-      # We are using the staging API for now:
-      CHARMSTORE_PUBLISHER_API_URL: https://api.staging.charmhub.io/
     steps:
     - uses: actions/checkout@v1
     - uses: dschep/install-poetry-action@v1.2

--- a/canonicalwebteam/store_api/store.py
+++ b/canonicalwebteam/store_api/store.py
@@ -173,11 +173,13 @@ class Store:
             self.session.post(url, headers=headers, json=json)
         )
 
-    def get_categories(self, api_version=1):
-        url = self.get_endpoint_url("sections")
+    def get_categories(self, api_version=2, type="shared"):
+        url = self.get_endpoint_url("categories", api_version)
 
         return self.process_response(
             self.session.get(
-                url, headers=self.config[api_version].get("headers")
+                url,
+                headers=self.config[api_version].get("headers"),
+                params={"type": type},
             )
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'canonicalwebteam.store-api'
-version = '2.3.2'
+version = '2.3.3'
 description = ''
 authors = ['Canonical Web Team <webteam@canonical.com>']
 license = 'LGPL-3.0'

--- a/tests/cassettes/CharmPublisherTest.test_get_account_packages_all_charms.yaml
+++ b/tests/cassettes/CharmPublisherTest.test_get_account_packages_all_charms.yaml
@@ -13,7 +13,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://api.staging.charmhub.io/v1/charm
+    uri: https://api.charmhub.io/v1/charm
   response:
     body:
       string: '{"charms":[{"authority":null,"charm-id":"1omXKR8ONGv5ZasymeAt9D1x1s0uflVg","contact":null,"description":null,"name":"francharm","package-type":"charm","private":false,"publisher":{"display-name":null,"id":"mGOTZu7OjyCKQxEL7kO7JKkTrHiKDrne","username":null,"validation":"unproven"},"status":"registered","store":"ubuntu","summary":null,"title":null,"website":null},{"authority":null,"charm-id":"EGnGTopcr5EUo2gvHZcCm7wZU66aHEDA","contact":"Francisco

--- a/tests/cassettes/CharmPublisherTest.test_get_account_packages_published_charms.yaml
+++ b/tests/cassettes/CharmPublisherTest.test_get_account_packages_published_charms.yaml
@@ -13,7 +13,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://api.staging.charmhub.io/v1/charm
+    uri: https://api.charmhub.io/v1/charm
   response:
     body:
       string: '{"charms":[{"authority":null,"charm-id":"1omXKR8ONGv5ZasymeAt9D1x1s0uflVg","contact":null,"description":null,"name":"francharm","package-type":"charm","private":false,"publisher":{"display-name":null,"id":"mGOTZu7OjyCKQxEL7kO7JKkTrHiKDrne","username":null,"validation":"unproven"},"status":"registered","store":"ubuntu","summary":null,"title":null,"website":null},{"authority":null,"charm-id":"EGnGTopcr5EUo2gvHZcCm7wZU66aHEDA","contact":"Francisco

--- a/tests/cassettes/CharmPublisherTest.test_get_account_packages_registered_charms.yaml
+++ b/tests/cassettes/CharmPublisherTest.test_get_account_packages_registered_charms.yaml
@@ -13,7 +13,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://api.staging.charmhub.io/v1/charm
+    uri: https://api.charmhub.io/v1/charm
   response:
     body:
       string: '{"charms":[{"authority":null,"charm-id":"1omXKR8ONGv5ZasymeAt9D1x1s0uflVg","contact":null,"description":null,"name":"francharm","package-type":"charm","private":false,"publisher":{"display-name":null,"id":"mGOTZu7OjyCKQxEL7kO7JKkTrHiKDrne","username":null,"validation":"unproven"},"status":"registered","store":"ubuntu","summary":null,"title":null,"website":null},{"authority":null,"charm-id":"EGnGTopcr5EUo2gvHZcCm7wZU66aHEDA","contact":"Francisco

--- a/tests/cassettes/CharmPublisherTest.test_get_macaroon.yaml
+++ b/tests/cassettes/CharmPublisherTest.test_get_macaroon.yaml
@@ -13,7 +13,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://api.staging.charmhub.io/v1/tokens
+    uri: https://api.charmhub.io/v1/tokens
   response:
     body:
       string: '{"macaroon":"{\"c\": [{\"i\": \"time-before 2021-07-15T15:33:12.630288Z\"},

--- a/tests/cassettes/CharmPublisherTest.test_whoami.yaml
+++ b/tests/cassettes/CharmPublisherTest.test_whoami.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://api.staging.charmhub.io/v1/whoami
+    uri: https://api.charmhub.io/v1/whoami
   response:
     body:
       string: '{"display-name":"Francisco Jim\u00e9nez Cabrera","id":"mGOTZu7OjyCKQxEL7kO7JKkTrHiKDrne","username":"jkfran"}

--- a/tests/cassettes/SnapStoreTest.test_get_categories.yaml
+++ b/tests/cassettes/SnapStoreTest.test_get_categories.yaml
@@ -8,50 +8,38 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.23.0
-      X-Ubuntu-Series:
+      Snap-Device-Series:
       - '16'
+      User-Agent:
+      - python-requests/2.24.0
     method: GET
-    uri: https://api.snapcraft.io/api/v1/snaps/sections
+    uri: https://api.snapcraft.io/v2/snaps/categories?type=shared
   response:
     body:
-      string: '{"_embedded": {"clickindex:sections": [{"name": "featured"}, {"name":
-        "games"}, {"name": "finance"}, {"name": "productivity"}, {"name": "utilities"},
-        {"name": "news-and-weather"}, {"name": "science"}, {"name": "health-and-fitness"},
-        {"name": "education"}, {"name": "personalisation"}, {"name": "devices-and-iot"},
-        {"name": "books-and-reference"}, {"name": "security"}, {"name": "music-and-audio"},
-        {"name": "social"}, {"name": "server-and-cloud"}, {"name": "development"},
-        {"name": "entertainment"}, {"name": "photo-and-video"}, {"name": "art-and-design"}]}}'
+      string: '{"categories":[{"name":"art-and-design"},{"name":"books-and-reference"},{"name":"development"},{"name":"devices-and-iot"},{"name":"education"},{"name":"entertainment"},{"name":"featured"},{"name":"finance"},{"name":"games"},{"name":"health-and-fitness"},{"name":"music-and-audio"},{"name":"news-and-weather"},{"name":"personalisation"},{"name":"photo-and-video"},{"name":"productivity"},{"name":"science"},{"name":"security"},{"name":"server-and-cloud"},{"name":"social"},{"name":"utilities"}]}
+
+        '
     headers:
-      Age:
-      - '2414'
       Cache-Control:
       - public, max-age=3600
       Content-Length:
-      - '558'
+      - '495'
       Content-Type:
-      - application/hal+json
+      - application/json
       Date:
-      - Mon, 20 Apr 2020 13:29:57 GMT
+      - Mon, 27 Jul 2020 17:06:36 GMT
       Server:
       - gunicorn/19.7.1
       Snap-Store-Version:
-      - '22'
+      - '23'
       Vary:
-      - X-Ubuntu-Series
-      Via:
-      - 1.1 juju-7794b8-prod-ols-snap-store-indep-1656 (squid/3.5.27)
-      X-Cache:
-      - HIT from juju-7794b8-prod-ols-snap-store-indep-1656
-      X-Cache-Lookup:
-      - HIT from juju-7794b8-prod-ols-snap-store-indep-1656:3128
+      - Snap-Device-Store
       X-Request-Id:
-      - 12D80C50D2680A325C8501BB5E9DA3CFA230660
+      - 0289F916DB680A325D3A01BB5F1F099C18DD238A
       X-VCS-Revision:
-      - 0bf41e1
+      - c7d9af9
       X-View-Name:
-      - snapdevicegw.webapi_search.section_listing
+      - snapdevicegw.webapi_categories.snaps_categories
     status:
       code: 200
       message: OK

--- a/tests/test_snapcraft_store_api.py
+++ b/tests/test_snapcraft_store_api.py
@@ -181,8 +181,7 @@ class SnapStoreTest(VCRTestCase):
         self.assertEqual("2019-12-01", result[0]["buckets"][0])
 
     def test_get_categories(self):
-        result = self.client.get_categories(api_version=1)
-        categories = result["_embedded"]["clickindex:sections"]
+        categories = self.client.get_categories(api_version=2)["categories"]
 
         for category in categories:
             self.assertIn("name", category)


### PR DESCRIPTION
## Done

- Update get_categories to use v2 API
- Use production for CharmHub publisher API

## Issue
Fixes https://github.com/canonical-web-and-design/canonicalwebteam.store-api/issues/35