### PR TITLE
Update API URL

### DIFF
--- a/canonicalwebteam/store_api/stores/charmstore.py
+++ b/canonicalwebteam/store_api/stores/charmstore.py
@@ -5,7 +5,7 @@ import requests
 from canonicalwebteam.store_api.store import Store
 from canonicalwebteam.store_api.publisher import Publisher
 
-CHARMSTORE_API_URL = getenv("CHARMSTORE_API_URL", "https://api.snapcraft.io/")
+CHARMSTORE_API_URL = getenv("CHARMSTORE_API_URL", "https://api.charmhub.io/")
 CHARMSTORE_PUBLISHER_API_URL = getenv(
     "CHARMSTORE_PUBLISHER_API_URL", "https://api.charmhub.io/"
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'canonicalwebteam.store-api'
-version = '3.1.4'
+version = '3.1.5'
 description = ''
 authors = ['Canonical Web Team <webteam@canonical.com>']
 license = 'LGPL-3.0'


### PR DESCRIPTION
The API needs to consume api.charmhub.io instead of api.snapcraft.io as it will stop working for charms.