### PR TITLE
Add macaroon_info for CharmStore

### DIFF
--- a/canonicalwebteam/store_api/stores/charmstore.py
+++ b/canonicalwebteam/store_api/stores/charmstore.py
@@ -74,6 +74,17 @@ class CharmPublisher(Publisher):
 
         return self.process_response(response)["macaroon"]
 
+    def macaroon_info(self, publisher_auth):
+        """
+        Return information about the authenticated macaroon token.
+        """
+        response = self.session.get(
+            url=self.get_endpoint_url("tokens/whoami"),
+            headers=self._get_authorization_header(publisher_auth),
+        )
+
+        return self.process_response(response)
+
     def whoami(self, publisher_auth):
         response = self.session.get(
             url=self.get_endpoint_url("whoami"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'canonicalwebteam.store-api'
-version = '3.2.6'
+version = '3.2.7'
 description = ''
 authors = ['Canonical Web Team <webteam@canonical.com>']
 license = 'LGPL-3.0'


### PR DESCRIPTION
## Done

- Added `macaroon_info` to consume endpoint https://api.charmhub.io/docs/default.html#macaroon_info
