### PR TITLE
fix: get correct auth header to delete package name

### DIFF
--- a/canonicalwebteam/store_api/publishergw.py
+++ b/canonicalwebteam/store_api/publishergw.py
@@ -307,7 +307,7 @@ class PublisherGW(Base):
         return self.process_response(response)
 
     def unregister_package_name(
-        self, session: dict, package_name: str
+        self, publisher_auth: str, package_name: str
     ) -> dict:
         """
         Unregister a package name.
@@ -325,7 +325,7 @@ class PublisherGW(Base):
         url = self.get_endpoint_url(package_name, has_name_space=True)
         response = self.session.delete(
             url=url,
-            headers=dashboard_authorization_header(session),
+            headers=self._get_authorization_header(publisher_auth),
         )
         return response
 


### PR DESCRIPTION
## Done
- Gets correct auth header to allow a charm owner to unregister a package name

## How to QA
- Check out this branch
- Run it locally with your local charmhub.io
- Go to localhost:8045/charms and try to unregister one of your registered charm names
- Make sure it unregisters

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): bug fix

## Issue / Card
Fixes [WD-22834](https://warthogs.atlassian.net/browse/WD-22834)

[WD-22834]: https://warthogs.atlassian.net/browse/WD-22834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ