### PR TITLE
fix: Return 404 if package metadata not found

### DIFF
--- a/canonicalwebteam/store_api/publishergw.py
+++ b/canonicalwebteam/store_api/publishergw.py
@@ -243,6 +243,9 @@ class PublisherGW(Base):
             headers=self._get_dev_token_authorization_header(session),
         )
 
+        if response.status_code == 404:
+            return self.process_response(response)
+
         return self.process_response(response)["metadata"]
 
     def update_package_metadata(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'canonicalwebteam.store-api'
-version = '6.3.0'
+version = '6.4.0'
 description = ''
 authors = ['Canonical Web Team <webteam@canonical.com>']
 license = 'LGPL-3.0'


### PR DESCRIPTION
## Done
Return `404` if package metadata not found which should resolve https://sentry.is.canonical.com/canonical/snapcraft-io/issues/99585/

## QA
- In your local snapcraft.io `requirements.txt` change `canonicalwebteam.store-api==6.2.0` to `git+https://github.com/canonical/canonicalwebteam.store-api@bf0df38bdba3c295bdb3613cea66c0973b1684d1`
- Run the project locally with `dotrun`
- Go to a private snap packages endpoint, e.g. http://localhost:8004/api/packages/chargebig18-36-loadmanagement
- The response should be `404`