### PR TITLE
feat: Update serial log request to accept serial assertion parameters

### DIFF
--- a/canonicalwebteam/store_api/publishergw.py
+++ b/canonicalwebteam/store_api/publishergw.py
@@ -727,6 +727,8 @@ class PublisherGW(Base):
         store_id: str,
         model_name: str,
         serial: str,
+        include_serial_assertion=None,
+        include_serial_request_assertion=None,
     ) -> dict:
         """
         Documentation:
@@ -735,15 +737,22 @@ class PublisherGW(Base):
             https://api.charmhub.io/v1/brand/{store_id}/model/{model_name}/serial/{serial}/serial-log
 
         """
+        request_url = self.get_endpoint_url(
+            f"brand/{store_id}/model/{model_name}/serial/{serial}/serial-log"
+        )
+
+        params = {}
+
+        if include_serial_assertion is not None:
+            params["include-serial-assertion"] = "true"
+
+        if include_serial_request_assertion is not None:
+            params["include-serial-request-assertion"] = "true"
+
         response = self.session.get(
-            url=self.get_endpoint_url(
-                (
-                    f"brand/{store_id}/model/{model_name}"
-                    f"/serial/{serial}/serial-log"
-                    f"?include-serial-assertion=true"
-                )
-            ),
+            url=request_url,
             headers=self._get_dev_token_authorization_header(session),
+            params=params,
         )
 
         return self.process_response(response)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'canonicalwebteam.store-api'
-version = '7.5.0'
+version = '7.6.0'
 description = ''
 authors = ['Canonical Web Team <webteam@canonical.com>']
 license = 'LGPL-3.0'

--- a/tests/cassettes/PublisherGWTest.test_get_store_model_serial_log.yaml
+++ b/tests/cassettes/PublisherGWTest.test_get_store_model_serial_log.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://api.charmhub.io/v1/brand/marketplace_test_store_id/model/test-model/serial/test-serial/serial-log?include-serial-assertion=true
+    uri: https://api.charmhub.io/v1/brand/marketplace_test_store_id/model/test-model/serial/test-serial/serial-log?include-serial-assertion=true&include-serial-request-assertion=true
   response:
     body:
         string: '{ "items": [], "next-cursor": null }'

--- a/tests/test_publisher_gateway.py
+++ b/tests/test_publisher_gateway.py
@@ -201,6 +201,8 @@ class PublisherGWTest(VCRTestCase):
             store_id="marketplace_test_store_id",
             model_name="test-model",
             serial="test-serial",
+            include_serial_assertion=True,
+            include_serial_request_assertion=True,
         )
         self.assertIsInstance(response, dict)
 


### PR DESCRIPTION
## Done
Updates the `get_store_model_serial_log` method to take `include-serial-assertion` and `include-serial-request-assertion` as optional parameters so they can be passed from the frontend as [documented in the API](include-serial-request-assertion)

## QA
All checks should pass

## Issue
Fixes https://warthogs.atlassian.net/browse/WD-35774