### PR TITLE
feat: Update serial logs request to accept pagination and time parameters

### DIFF
--- a/canonicalwebteam/store_api/publishergw.py
+++ b/canonicalwebteam/store_api/publishergw.py
@@ -704,6 +704,10 @@ class PublisherGW(Base):
         session: dict,
         store_id: str,
         model_name: str,
+        start_time=None,
+        end_time=None,
+        page_size=None,
+        cursor=None,
     ) -> dict:
         """
         Documentation:
@@ -712,11 +716,28 @@ class PublisherGW(Base):
             https://api.charmhub.io/v1/brand/{store_id}/model/{model_name}/serial-log
 
         """
+        request_url = self.get_endpoint_url(
+            f"brand/{store_id}/model/{model_name}/serial-log"
+        )
+
+        params = {}
+
+        if start_time is not None:
+            params["start-time"] = start_time
+
+        if end_time is not None:
+            params["end-time"] = end_time
+
+        if page_size is not None:
+            params["page-size"] = page_size
+
+        if cursor is not None:
+            params["cursor"] = cursor
+
         response = self.session.get(
-            url=self.get_endpoint_url(
-                f"brand/{store_id}/model/{model_name}/serial-log"
-            ),
+            url=request_url,
             headers=self._get_dev_token_authorization_header(session),
+            params=params,
         )
 
         return self.process_response(response)
@@ -727,6 +748,8 @@ class PublisherGW(Base):
         store_id: str,
         model_name: str,
         serial: str,
+        include_serial_assertion=None,
+        include_serial_request_assertion=None,
     ) -> dict:
         """
         Documentation:
@@ -735,15 +758,22 @@ class PublisherGW(Base):
             https://api.charmhub.io/v1/brand/{store_id}/model/{model_name}/serial/{serial}/serial-log
 
         """
+        request_url = self.get_endpoint_url(
+            f"brand/{store_id}/model/{model_name}/serial/{serial}/serial-log"
+        )
+
+        params = {}
+
+        if include_serial_assertion is not None:
+            params["include-serial-assertion"] = "true"
+
+        if include_serial_request_assertion is not None:
+            params["include-serial-request-assertion"] = "true"
+
         response = self.session.get(
-            url=self.get_endpoint_url(
-                (
-                    f"brand/{store_id}/model/{model_name}"
-                    f"/serial/{serial}/serial-log"
-                    f"?include-serial-assertion=true"
-                )
-            ),
+            url=request_url,
             headers=self._get_dev_token_authorization_header(session),
+            params=params,
         )
 
         return self.process_response(response)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'canonicalwebteam.store-api'
-version = '7.5.0'
+version = '7.7.0'
 description = ''
 authors = ['Canonical Web Team <webteam@canonical.com>']
 license = 'LGPL-3.0'

--- a/tests/cassettes/PublisherGWTest.test_get_store_model_serial_log.yaml
+++ b/tests/cassettes/PublisherGWTest.test_get_store_model_serial_log.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://api.charmhub.io/v1/brand/marketplace_test_store_id/model/test-model/serial/test-serial/serial-log?include-serial-assertion=true
+    uri: https://api.charmhub.io/v1/brand/marketplace_test_store_id/model/test-model/serial/test-serial/serial-log?include-serial-assertion=true&include-serial-request-assertion=true
   response:
     body:
         string: '{ "items": [], "next-cursor": null }'

--- a/tests/cassettes/PublisherGWTest.test_get_store_model_serial_logs.yaml
+++ b/tests/cassettes/PublisherGWTest.test_get_store_model_serial_logs.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://api.charmhub.io/v1/brand/marketplace_test_store_id/model/test-model/serial-log
+    uri: https://api.charmhub.io/v1/brand/marketplace_test_store_id/model/test-model/serial-log?start-time=2025-03-20T05:19:52.00&end-time=2026-03-20T05:19:52.00&page-size=10&cursor=next
   response:
     body:
         string: '{ "items": [], "next-cursor": null }'

--- a/tests/test_publisher_gateway.py
+++ b/tests/test_publisher_gateway.py
@@ -192,6 +192,10 @@ class PublisherGWTest(VCRTestCase):
             test_dev_auth,
             store_id="marketplace_test_store_id",
             model_name="test-model",
+            start_time="2025-03-20T05:19:52.00",
+            end_time="2026-03-20T05:19:52.00",
+            page_size=10,
+            cursor="next",
         )
         self.assertIsInstance(response, dict)
 
@@ -201,6 +205,8 @@ class PublisherGWTest(VCRTestCase):
             store_id="marketplace_test_store_id",
             model_name="test-model",
             serial="test-serial",
+            include_serial_assertion=True,
+            include_serial_request_assertion=True,
         )
         self.assertIsInstance(response, dict)
 


### PR DESCRIPTION
## Done
Updates the `get_store_model_serial_logs` method to take `start-time`, `end-time`, `page-size` and `cursor` as optional parameters so they can be passed from the frontend as [documented in the API](https://api.charmhub.io/docs/model-service-admin/#read-serial-logs-by-time)

## QA
All checks should pass

## Issue
Fixes https://warthogs.atlassian.net/browse/WD-35775