### PR TITLE
feat: Add methods to update and delete remodel allowlists

### DIFF
--- a/canonicalwebteam/store_api/publishergw.py
+++ b/canonicalwebteam/store_api/publishergw.py
@@ -928,6 +928,48 @@ class PublisherGW(Base):
 
         return self.process_response(response)
 
+    def update_remodel_allowlist(
+        self, session: dict, store_id: str, allowlist: list[dict]
+    ) -> dict:
+        """
+        Documentation:
+            https://api.charmhub.io/docs/model-service-admin.html
+                #update-remodel-allowlist
+        Endpoint: [PATCH]
+            https://api.charmhub.io/v1/brand/{store_id}/remodel-allowlist
+        """
+        payload = {"allowlist": allowlist}
+
+        response = self.session.patch(
+            url=self.get_endpoint_url(f"brand/{store_id}/remodel-allowlist"),
+            headers=self._get_dev_token_authorization_header(session),
+            json=payload,
+        )
+
+        return self.process_response(response)
+
+    def delete_remodel_allowlist(
+        self, session: dict, store_id: str, allowlist: list[dict]
+    ) -> dict:
+        """
+        Documentation:
+            https://api.charmhub.io/docs/model-service-admin.html
+                #delete-remodel-allowlist
+        Endpoint: [POST]
+            https://api.charmhub.io/v1/brand/{store_id}/remodel-allowlist/delete
+        """
+        payload = {"allowlist": allowlist}
+
+        response = self.session.post(
+            url=self.get_endpoint_url(
+                f"brand/{store_id}/remodel-allowlist/delete"
+            ),
+            headers=self._get_dev_token_authorization_header(session),
+            json=payload,
+        )
+
+        return response
+
     def get_brand(self, session: dict, store_id: str) -> dict:
         """
         Documentation:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'canonicalwebteam.store-api'
-version = '7.7.0'
+version = '7.8.0'
 description = ''
 authors = ['Canonical Web Team <webteam@canonical.com>']
 license = 'LGPL-3.0'

--- a/tests/cassettes/PublisherGWTest.test_delete_remodel_allowlist.yaml
+++ b/tests/cassettes/PublisherGWTest.test_delete_remodel_allowlist.yaml
@@ -1,0 +1,45 @@
+interactions:
+- request:
+    body: '{"allowlist": [{"from-model": "test-from-model", "to-model": "test-to-model",
+      "from-serial": "test-serial"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '109'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://api.charmhub.io/v1/brand/marketplace_test_store_id/remodel-allowlist/delete
+  response:
+    body:
+      string: '{"error-list":[{"code":"api-error","message":"Invalid macaroon"}]}
+
+        '
+    headers:
+      content-length:
+      - '67'
+      content-type:
+      - application/json
+      date:
+      - Wed, 22 Apr 2026 08:26:57 GMT
+      publishergw-version:
+      - '66'
+      server:
+      - gunicorn
+      x-request-id:
+      - 2A0023C73D042A01C4541B269722FF94D2862620002D40001010000000000000011701BB69E886514ED4F6C
+      x-vcs-revision:
+      - 63983ae640fb0c414534facedb3f85eedc6d4f32
+      x-view-name:
+      - publishergw.webapi_admin.delete_remodel_allowlist
+    status:
+      code: 400
+      message: BAD REQUEST
+version: 1

--- a/tests/cassettes/PublisherGWTest.test_update_remodel_allowlist.yaml
+++ b/tests/cassettes/PublisherGWTest.test_update_remodel_allowlist.yaml
@@ -1,0 +1,47 @@
+interactions:
+  - request:
+      body:
+        '{"allowlist": [{"from-model": "test-from-model", "to-model": "test-to-model",
+        "from-serial": "test-serial", "description": "Updated test description"}]}'
+      headers:
+        Accept:
+          - "*/*"
+        Accept-Encoding:
+          - gzip, deflate, zstd
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "152"
+        Content-Type:
+          - application/json
+        User-Agent:
+          - python-requests/2.32.5
+      method: PATCH
+      uri: https://api.charmhub.io/v1/brand/marketplace_test_store_id/remodel-allowlist
+    response:
+      body:
+        string:
+          '{"allowlist": [{"from-model": "test-from-model", "to-model": "test-to-model", "from-serial": "test-serial", "description": "Updated test description", "created-at": "2026-04-21T09:20:00.000Z", "created-by": "test-user", "modified-at": "2026-04-21T09:24:30.000Z", "modified-by": "test-user"}]}
+
+          '
+      headers:
+        content-length:
+          - "245"
+        content-type:
+          - application/json
+        date:
+          - Tue, 21 Apr 2026 09:24:30 GMT
+        publishergw-version:
+          - "66"
+        server:
+          - gunicorn
+        x-request-id:
+          - 2A0023C73D042A01C5D3CA3BF1D6C234FE2A2620002D4000101000000000000002CC01BB69E7424ED194994
+        x-vcs-revision:
+          - 63983ae640fb0c414534facedb3f85eedc6d4f32
+        x-view-name:
+          - publishergw.webapi_admin.update_remodel_allowlist
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/test_publisher_gateway.py
+++ b/tests/test_publisher_gateway.py
@@ -179,6 +179,38 @@ class PublisherGWTest(VCRTestCase):
         )
         self.assertEqual("test-to-model", response["allowlist"][0]["to-model"])
 
+    def test_update_remodel_allowlist(self):
+        response = self.client.update_remodel_allowlist(
+            test_dev_auth,
+            store_id="marketplace_test_store_id",
+            allowlist=[
+                {
+                    "from-model": "test-from-model",
+                    "to-model": "test-to-model",
+                    "from-serial": "test-serial",
+                    "description": "Updated test description",
+                }
+            ],
+        )
+        self.assertEqual(
+            "Updated test description", response["allowlist"][0]["description"]
+        )
+        self.assertEqual("test-to-model", response["allowlist"][0]["to-model"])
+
+    def test_delete_remodel_allowlist(self):
+        response = self.client.delete_remodel_allowlist(
+            test_dev_auth,
+            store_id="marketplace_test_store_id",
+            allowlist=[
+                {
+                    "from-model": "test-from-model",
+                    "to-model": "test-to-model",
+                    "from-serial": "test-serial",
+                }
+            ],
+        )
+        self.assertEqual(response.status_code, 400)
+
     def test_get_store_model_policies(self):
         response = self.client.get_store_model_policies(
             test_dev_auth,


### PR DESCRIPTION
## Done

Adds methods to update and delete remodel allowlists as documented in the API:
- Update: https://api.staging.charmhub.io/docs/model-service-admin/#update-remodel-allowlist
- Delete: https://api.staging.charmhub.io/docs/model-service-admin/#delete-remodel-allowlist

## QA
All checks should pass

## Issue
Fixes https://warthogs.atlassian.net/browse/WD-36210