### PR TITLE
fix: Process the response of delete allowlist

### DIFF
--- a/canonicalwebteam/store_api/publishergw.py
+++ b/canonicalwebteam/store_api/publishergw.py
@@ -968,7 +968,7 @@ class PublisherGW(Base):
             json=payload,
         )
 
-        return response
+        return self.process_response(response)
 
     def get_brand(self, session: dict, store_id: str) -> dict:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'canonicalwebteam.store-api'
-version = '7.8.0'
+version = '7.8.1'
 description = ''
 authors = ['Canonical Web Team <webteam@canonical.com>']
 license = 'LGPL-3.0'

--- a/tests/test_publisher_gateway.py
+++ b/tests/test_publisher_gateway.py
@@ -4,6 +4,7 @@ from vcr_unittest import VCRTestCase
 from canonicalwebteam.store_api.publishergw import PublisherGW
 from canonicalwebteam.exceptions import (
     StoreApiResponseError,
+    StoreApiResponseErrorList,
 )
 
 test_session = getenv(
@@ -198,18 +199,18 @@ class PublisherGWTest(VCRTestCase):
         self.assertEqual("test-to-model", response["allowlist"][0]["to-model"])
 
     def test_delete_remodel_allowlist(self):
-        response = self.client.delete_remodel_allowlist(
-            test_dev_auth,
-            store_id="marketplace_test_store_id",
-            allowlist=[
-                {
-                    "from-model": "test-from-model",
-                    "to-model": "test-to-model",
-                    "from-serial": "test-serial",
-                }
-            ],
-        )
-        self.assertEqual(response.status_code, 400)
+        with self.assertRaises(StoreApiResponseErrorList):
+            self.client.delete_remodel_allowlist(
+                test_dev_auth,
+                store_id="marketplace_test_store_id",
+                allowlist=[
+                    {
+                        "from-model": "test-from-model",
+                        "to-model": "test-to-model",
+                        "from-serial": "test-serial",
+                    }
+                ],
+            )
 
     def test_get_store_model_policies(self):
         response = self.client.get_store_model_policies(


### PR DESCRIPTION
## Done
Wrapped the response for deleting allowlists in `process_response` so frontend can handle it correctly

## QA
All checks should pass