### PR TITLE
feat: Update get remodels endpoint to accept query parameters

### DIFF
--- a/canonicalwebteam/store_api/publishergw.py
+++ b/canonicalwebteam/store_api/publishergw.py
@@ -892,7 +892,9 @@ class PublisherGW(Base):
 
         return response
 
-    def get_remodel_allowlist(self, session: dict, store_id: str) -> dict:
+    def get_remodel_allowlist(
+        self, session: dict, store_id: str, params: dict
+    ) -> dict:
         """
         Documentation:
             https://api.charmhub.io/docs/model-service-admin.html
@@ -901,9 +903,21 @@ class PublisherGW(Base):
             [GET]
             https://api.charmhub.io/v1/brand/{store_id}/remodel-allowlist
         """
+        query_params = {}
+
+        if params["cursor"] is not None:
+            query_params["cursor"] = params["cursor"]
+
+        if params["from-model"] is not None:
+            query_params["from-model"] = params["from-model"]
+
+        if params["page-size"] is not None:
+            query_params["page-size"] = params["page-size"]
+
         response = self.session.get(
             url=self.get_endpoint_url(f"brand/{store_id}/remodel-allowlist"),
             headers=self._get_dev_token_authorization_header(session),
+            params=query_params,
         )
 
         return self.process_response(response)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'canonicalwebteam.store-api'
-version = '7.8.1'
+version = '7.8.2'
 description = ''
 authors = ['Canonical Web Team <webteam@canonical.com>']
 license = 'LGPL-3.0'

--- a/tests/test_publisher_gateway.py
+++ b/tests/test_publisher_gateway.py
@@ -154,8 +154,14 @@ class PublisherGWTest(VCRTestCase):
         response = self.client.get_remodel_allowlist(
             test_dev_auth,
             store_id="marketplace_test_store_id",
+            params={
+                "cursor": None,
+                "from-model": None,
+                "page-size": None,
+            },
         )
         self.assertIsInstance(response, dict)
+        self.assertIn("allowlist", response)
 
     def test_create_store_model(self):
         response = self.client.create_store_model(


### PR DESCRIPTION
## Done
Updates `get_remodel_allowlist` to accept and forward parameters for `cursor`, `page-size` and `from-model` which are all accepted by the [Store API](https://api.charmhub.io/docs/model-service-admin/#read-remodel-allowlist)

## QA
All required checks should pass