### PR TITLE
chore: Update get_store_model_serial_logs to accept query params

### DIFF
--- a/canonicalwebteam/store_api/publishergw.py
+++ b/canonicalwebteam/store_api/publishergw.py
@@ -700,14 +700,7 @@ class PublisherGW(Base):
         return self.process_response(response)
 
     def get_store_model_serial_logs(
-        self,
-        session: dict,
-        store_id: str,
-        model_name: str,
-        start_time=None,
-        end_time=None,
-        page_size=None,
-        cursor=None,
+        self, session: dict, store_id: str, model_name: str, params: dict
     ) -> dict:
         """
         Documentation:
@@ -720,24 +713,24 @@ class PublisherGW(Base):
             f"brand/{store_id}/model/{model_name}/serial-log"
         )
 
-        params = {}
+        query_params = {}
 
-        if start_time is not None:
-            params["start-time"] = start_time
+        if params["start_time"] is not None:
+            query_params["start-time"] = params["start_time"]
 
-        if end_time is not None:
-            params["end-time"] = end_time
+        if params["end_time"] is not None:
+            query_params["end-time"] = params["end_time"]
 
-        if page_size is not None:
-            params["page-size"] = page_size
+        if params["page_size"] is not None:
+            query_params["page-size"] = params["page_size"]
 
-        if cursor is not None:
-            params["cursor"] = cursor
+        if params["cursor"] is not None:
+            query_params["cursor"] = params["cursor"]
 
         response = self.session.get(
             url=request_url,
             headers=self._get_dev_token_authorization_header(session),
-            params=params,
+            params=query_params,
         )
 
         return self.process_response(response)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'canonicalwebteam.store-api'
-version = '7.8.2'
+version = '7.8.3'
 description = ''
 authors = ['Canonical Web Team <webteam@canonical.com>']
 license = 'LGPL-3.0'

--- a/tests/test_publisher_gateway.py
+++ b/tests/test_publisher_gateway.py
@@ -231,12 +231,15 @@ class PublisherGWTest(VCRTestCase):
             test_dev_auth,
             store_id="marketplace_test_store_id",
             model_name="test-model",
-            start_time="2025-03-20T05:19:52.00",
-            end_time="2026-03-20T05:19:52.00",
-            page_size=10,
-            cursor="next",
+            params={
+                "start_time": "2025-03-20T05:19:52.00",
+                "end_time": "2026-03-20T05:19:52.00",
+                "page_size": 10,
+                "cursor": "next",
+            },
         )
         self.assertIsInstance(response, dict)
+        self.assertIn("items", response)
 
     def test_get_store_model_serial_log(self):
         response = self.client.get_store_model_serial_log(


### PR DESCRIPTION
## Done
Updates `get_store_model_serial_logs` to accept and forward parameters for `cursor`, `page-size`, `start-time` and `end-time` which are all accepted by the [Store API](https://api.charmhub.io/docs/model-service-admin/#read-serial-logs-by-time)

## QA
All required checks should pass