### PR TITLE
remove Candid from PublisherGW authentication

### DIFF
--- a/canonicalwebteam/store_api/base.py
+++ b/canonicalwebteam/store_api/base.py
@@ -114,6 +114,10 @@ class Base:
             raise PublisherMacaroonRefreshRequired
 
         if not response.ok:
+            if self._requires_macaroon_reauth(response, body):
+                logger.error("Publisher macaroon reauthentication required")
+                raise PublisherMacaroonRefreshRequired
+
             self.log_detailed_error(response)
             error_list = (
                 body["error_list"]
@@ -141,6 +145,18 @@ class Base:
                 raise StoreApiResponseError(
                     "Unknown error from api", response.status_code
                 )
+            else:
+                message = (
+                    body.get("Message")
+                    if isinstance(body, dict)
+                    else "Unknown error from api"
+                )
+                if not message and isinstance(body, dict):
+                    message = body.get("message")
+                raise StoreApiResponseError(
+                    message or "Unknown error from api",
+                    response.status_code,
+                )
 
         return body
 
@@ -150,3 +166,22 @@ class Base:
         the header response.
         """
         return headers.get("WWW-Authenticate") == ("Macaroon needs_refresh=1")
+
+    def _requires_macaroon_reauth(self, response, body):
+        if response.status_code != 401:
+            return False
+
+        www_authenticate = (
+            response.headers.get("WWW-Authenticate")
+            or response.headers.get("www-authenticate")
+            or ""
+        )
+        if "macaroon" in www_authenticate.lower():
+            return True
+
+        if not isinstance(body, dict):
+            return False
+
+        error_code = str(body.get("Code", "")).lower()
+        message = str(body.get("Message", "")).lower()
+        return "macaroon" in error_code or "discharge required" in message

--- a/canonicalwebteam/store_api/dashboard.py
+++ b/canonicalwebteam/store_api/dashboard.py
@@ -48,7 +48,6 @@ class Dashboard(Base):
             return {
                 "Authorization": f"macaroon root={root}, discharge={bound}"
             }
-        # With Candid the header is Macaroons
         elif "macaroons" in session:
             return {"Macaroons": session["macaroons"]}
         return {"Macaroons": ""}

--- a/canonicalwebteam/store_api/publishergw.py
+++ b/canonicalwebteam/store_api/publishergw.py
@@ -140,8 +140,6 @@ class PublisherGW(Base):
         Return a root macaroon to be discharged by Ubuntu SSO.
         Endpoint URL: [POST] https://api.charmhub.io/v1/tokens/usso
         """
-        if ttl is None:
-            raise ValueError("ttl is required")
         if not permissions:
             raise ValueError("permissions must contain at least one entry")
 
@@ -194,7 +192,9 @@ class PublisherGW(Base):
             url=self.get_endpoint_url("tokens/usso/exchange"),
             headers={
                 "Authorization": (
-                    f"Macaroon root={root_macaroon}, discharge={discharge_macaroon}"
+                    "Macaroon "
+                    f"root={root_macaroon}, "
+                    f"discharge={discharge_macaroon}"
                 )
             },
             json=data,

--- a/canonicalwebteam/store_api/publishergw.py
+++ b/canonicalwebteam/store_api/publishergw.py
@@ -111,7 +111,7 @@ class PublisherGW(Base):
         ttl: Optional[list] = None,
     ) -> str:
         """
-        Return a bakery v2 macaroon to be discharged by Candid.
+        Return a bakery v2 macaroon to be discharged by Ubuntu SSO.
         Documentation: https://api.charmhub.io/docs/default.html#issue_macaroon
         Endpoint URL: [POST] https://api.charmhub.io/v1/tokens
         """
@@ -129,6 +129,37 @@ class PublisherGW(Base):
         )
         return self.process_response(response)["macaroon"]
 
+    def issue_usso_macaroon(
+        self,
+        ttl: int,
+        permissions: list,
+        channels: Optional[list] = None,
+        packages: Optional[list] = None,
+    ) -> str:
+        """
+        Return a root macaroon to be discharged by Ubuntu SSO.
+        Endpoint URL: [POST] https://api.charmhub.io/v1/tokens/usso
+        """
+        if ttl is None:
+            raise ValueError("ttl is required")
+        if not permissions:
+            raise ValueError("permissions must contain at least one entry")
+
+        data = {"ttl": ttl, "permissions": permissions}
+
+        if channels is not None:
+            data["channels"] = channels
+
+        if packages is not None:
+            data["packages"] = packages
+
+        response = self.session.post(
+            url=self.get_endpoint_url("tokens/usso"),
+            json=data,
+        )
+
+        return self.process_response(response)["macaroon"]
+
     def exchange_macaroons(self, issued_macaroon: str) -> str:
         """
         Return an exchanged snapstore-only authentication macaroon.
@@ -141,6 +172,32 @@ class PublisherGW(Base):
             url=self.get_endpoint_url("tokens/exchange"),
             headers={"Macaroons": issued_macaroon},
             json={},
+        )
+
+        return self.process_response(response)["macaroon"]
+
+    def exchange_usso_macaroons(
+        self,
+        root_macaroon: str,
+        discharge_macaroon: str,
+        client_description: Optional[str] = None,
+    ) -> str:
+        """
+        Return an exchanged snapstore-only authentication macaroon.
+        Endpoint URL: [POST] https://api.charmhub.io/v1/tokens/usso/exchange
+        """
+        data = {}
+        if client_description is not None:
+            data["client-description"] = client_description
+
+        response = self.session.post(
+            url=self.get_endpoint_url("tokens/usso/exchange"),
+            headers={
+                "Authorization": (
+                    f"Macaroon root={root_macaroon}, discharge={discharge_macaroon}"
+                )
+            },
+            json=data,
         )
 
         return self.process_response(response)["macaroon"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'canonicalwebteam.store-api'
-version = '7.9.0'
+version = '8.0.0'
 description = ''
 authors = ['Canonical Web Team <webteam@canonical.com>']
 license = 'LGPL-3.0'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'canonicalwebteam.store-api'
-version = '7.8.3'
+version = '7.9.0'
 description = ''
 authors = ['Canonical Web Team <webteam@canonical.com>']
 license = 'LGPL-3.0'

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -6,6 +6,7 @@ from typing import Dict, cast
 from unittest.mock import Mock, MagicMock
 
 from canonicalwebteam.exceptions import (
+    PublisherMacaroonRefreshRequired,
     StoreApiInternalError,
     StoreApiNotImplementedError,
     StoreApiBadGatewayError,
@@ -102,4 +103,27 @@ class TestBase(unittest.TestCase):
     def test_process_response_ok(self):
         response = build_response(200)
         with self.assertNoLogs(logger=LOGGER):
+            self.client.process_response(response)
+
+    def test_process_response_requires_macaroon_reauth(self):
+        response = build_response(401)
+        response.headers = {"WWW-Authenticate": "Macaroon"}
+        response.json = MagicMock(
+            return_value={
+                "Code": "macaroon discharge required",
+                "Message": "discharge required",
+            }
+        )
+
+        with self.assertRaises(PublisherMacaroonRefreshRequired):
+            self.client.process_response(response)
+
+    def test_process_response_not_ok_with_non_error_list(self):
+        response = build_response(401)
+        response.headers = {}
+        response.json = MagicMock(
+            return_value={"code": "unauthorized", "message": "Unauthorized"}
+        )
+
+        with self.assertRaises(StoreApiResponseError):
             self.client.process_response(response)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -105,9 +105,17 @@ class TestBase(unittest.TestCase):
         with self.assertNoLogs(logger=LOGGER):
             self.client.process_response(response)
 
-    def test_process_response_requires_macaroon_reauth(self):
+    def test_process_response_requires_macaroon_reauth_header(self):
         response = build_response(401)
         response.headers = {"WWW-Authenticate": "Macaroon"}
+        response.json = MagicMock(return_value={"code": "unauthorized"})
+
+        with self.assertRaises(PublisherMacaroonRefreshRequired):
+            self.client.process_response(response)
+
+    def test_process_response_requires_macaroon_reauth_body(self):
+        response = build_response(401)
+        response.headers = {}
         response.json = MagicMock(
             return_value={
                 "Code": "macaroon discharge required",

--- a/tests/test_publisher_gateway.py
+++ b/tests/test_publisher_gateway.py
@@ -54,10 +54,10 @@ class PublisherGWTest(VCRTestCase):
             )
 
     def test_get_package_metadata_key_error(self):
-        response = self.client.get_package_metadata(
-            test_dev_auth, package_name="marketplace-test-charm4"
-        )
-        self.assertEqual(response["error"], "Some error")
+        with self.assertRaises(StoreApiResponseError):
+            self.client.get_package_metadata(
+                test_dev_auth, package_name="marketplace-test-charm4"
+            )
 
     def test_update_package_metadata(self):
         metadata = self.client.update_package_metadata(

--- a/tests/test_publisher_gateway_auth.py
+++ b/tests/test_publisher_gateway_auth.py
@@ -1,0 +1,72 @@
+import unittest
+from unittest.mock import Mock
+
+from requests import Session
+from requests.models import Response
+
+from canonicalwebteam.store_api.publishergw import PublisherGW
+
+
+def make_ok_response(body):
+    response = Mock(spec=Response)
+    response.status_code = 200
+    response.ok = True
+    response.headers = {}
+    response.json = Mock(return_value=body)
+    return response
+
+
+class TestPublisherGWAuth(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.session = Mock(spec=Session)
+        self.client = PublisherGW("charm", self.session)
+
+    def test_issue_usso_macaroon(self):
+        self.session.post.return_value = make_ok_response(
+            {"macaroon": "test-root"}
+        )
+
+        macaroon = self.client.issue_usso_macaroon(
+            ttl=300,
+            permissions=["account-view-packages"],
+            channels=["stable"],
+            packages=[{"type": "charm", "name": "my-charm"}],
+        )
+
+        self.assertEqual(macaroon, "test-root")
+        self.session.post.assert_called_once_with(
+            url=self.client.get_endpoint_url("tokens/usso"),
+            json={
+                "ttl": 300,
+                "permissions": ["account-view-packages"],
+                "channels": ["stable"],
+                "packages": [{"type": "charm", "name": "my-charm"}],
+            },
+        )
+
+    def test_issue_usso_macaroon_permissions_required(self):
+        with self.assertRaises(ValueError):
+            self.client.issue_usso_macaroon(ttl=300, permissions=[])
+
+    def test_exchange_usso_macaroons(self):
+        self.session.post.return_value = make_ok_response(
+            {"macaroon": "test-auth"}
+        )
+
+        macaroon = self.client.exchange_usso_macaroons(
+            root_macaroon="root-macaroon",
+            discharge_macaroon="discharge-macaroon",
+            client_description="charmhub.io - test-agent",
+        )
+
+        self.assertEqual(macaroon, "test-auth")
+        self.session.post.assert_called_once_with(
+            url=self.client.get_endpoint_url("tokens/usso/exchange"),
+            headers={
+                "Authorization": (
+                    "Macaroon root=root-macaroon, discharge=discharge-macaroon"
+                )
+            },
+            json={"client-description": "charmhub.io - test-agent"},
+        )


### PR DESCRIPTION
This PR adds the new authentication endpoints that replace candid auth (which is now deprecated).

To test this see instructions [here](https://github.com/canonical/charmhub.io/pull/2329)