### PR TITLE
feat: Add to-model parameter to the remodel allowlist endpoint

### DIFF
--- a/canonicalwebteam/store_api/publishergw.py
+++ b/canonicalwebteam/store_api/publishergw.py
@@ -958,8 +958,11 @@ class PublisherGW(Base):
         if params["cursor"] is not None:
             query_params["cursor"] = params["cursor"]
 
-        if params["from-model"] is not None:
+        if params.get("from-model") is not None:
             query_params["from-model"] = params["from-model"]
+
+        if params.get("to-model") is not None:
+            query_params["to-model"] = params.get("to-model")
 
         if params["page-size"] is not None:
             query_params["page-size"] = params["page-size"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'canonicalwebteam.store-api'
-version = '8.0.0'
+version = '8.1.0'
 description = ''
 authors = ['Canonical Web Team <webteam@canonical.com>']
 license = 'LGPL-3.0'

--- a/tests/cassettes/PublisherGWTest.test_get_remodel_allowlist_with_to_model.yaml
+++ b/tests/cassettes/PublisherGWTest.test_get_remodel_allowlist_with_to_model.yaml
@@ -1,0 +1,38 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.5
+    method: GET
+    uri: https://api.charmhub.io/v1/brand/marketplace_test_store_id/remodel-allowlist?to-model=test-to-model
+  response:
+    body:
+        string: '{ "allowlist": [], "next-cursor": null }'
+    headers:
+      content-length:
+      - '67'
+      content-type:
+      - application/json
+      date:
+      - Mon, 02 Feb 2026 11:34:11 GMT
+      publishergw-version:
+      - '65'
+      server:
+      - gunicorn
+      x-request-id:
+      - 2A0023C73D042A01C09693AE01A2D034CBB82620002D4000101000000000000002D601BB69808BB312B117D1
+      x-vcs-revision:
+      - aaaeca13d76052855b06ea6842ea2c066ce06eb4
+      x-view-name:
+      - publishergw.webapi_admin.read_remodel_allowlist
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_publisher_gateway.py
+++ b/tests/test_publisher_gateway.py
@@ -157,11 +157,27 @@ class PublisherGWTest(VCRTestCase):
             params={
                 "cursor": None,
                 "from-model": None,
+                "to-model": None,
                 "page-size": None,
             },
         )
         self.assertIsInstance(response, dict)
         self.assertIn("allowlist", response)
+
+    def test_get_remodel_allowlist_with_to_model(self):
+        response = self.client.get_remodel_allowlist(
+            test_dev_auth,
+            store_id="marketplace_test_store_id",
+            params={
+                "cursor": None,
+                "from-model": None,
+                "to-model": "test-to-model",
+                "page-size": None,
+            },
+        )
+        self.assertIsInstance(response, dict)
+        self.assertIn("allowlist", response)
+        self.assertIn("to-model=test-to-model", self.cassette.requests[0].uri)
 
     def test_create_store_model(self):
         response = self.client.create_store_model(


### PR DESCRIPTION
## Done
Adds the `to-model` parameter to the `get_remodel_allowlist` endpoint

## QA
All checks should pass