### PR TITLE
improve api error messaging

### DIFF
--- a/canonicalwebteam/store_api/publishergw.py
+++ b/canonicalwebteam/store_api/publishergw.py
@@ -637,6 +637,8 @@ class PublisherGW(Base):
             headers=self._get_authorization_header(publisher_auth),
             json={"token": token},
         )
+        if not response.ok:
+            self.process_response(response)
         return response
 
     def reject_invite(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'canonicalwebteam.store-api'
-version = '8.1.0'
+version = '8.2.0'
 description = ''
 authors = ['Canonical Web Team <webteam@canonical.com>']
 license = 'LGPL-3.0'

--- a/tests/test_publisher_gateway.py
+++ b/tests/test_publisher_gateway.py
@@ -157,10 +157,12 @@ class PublisherGWTest(VCRTestCase):
         response.request.headers = {}
         response.request._cookies = {}
         response.request.body = '{"token":"test-token"}'
-        self.client.session.post = Mock(return_value=response)
+        session = Mock()
+        session.post.return_value = response
+        client = PublisherGW("charm", session=session)
 
         with self.assertRaises(StoreApiResponseErrorList) as context:
-            self.client.accept_invite(
+            client.accept_invite(
                 test_session,
                 package_name="test",
                 token="test-token",

--- a/tests/test_publisher_gateway.py
+++ b/tests/test_publisher_gateway.py
@@ -1,4 +1,5 @@
 from os import getenv
+from unittest.mock import Mock
 
 from vcr_unittest import VCRTestCase
 from canonicalwebteam.store_api.publishergw import PublisherGW
@@ -134,6 +135,41 @@ class PublisherGWTest(VCRTestCase):
             emails=["alimot.akinbode@test.canonical.com"],
         )
         self.assertEqual(response.status_code, 204)
+
+    def test_accept_invite_error_raises_error_list(self):
+        response = Mock(
+            ok=False,
+            status_code=400,
+            headers={},
+            cookies={},
+            text='{"error-list":[{"code":"invalid-token"}]}',
+            url=(
+                "https://api.charmhub.io/v1/charm/test/"
+                "collaborators/invites/accept"
+            ),
+        )
+        response.json.return_value = {
+            "error-list": [
+                {"code": "invalid-token", "message": "Invalid invite token"}
+            ]
+        }
+        response.request.url = response.url
+        response.request.headers = {}
+        response.request._cookies = {}
+        response.request.body = '{"token":"test-token"}'
+        self.client.session.post = Mock(return_value=response)
+
+        with self.assertRaises(StoreApiResponseErrorList) as context:
+            self.client.accept_invite(
+                test_session,
+                package_name="test",
+                token="test-token",
+            )
+
+        self.assertEqual(context.exception.status_code, 400)
+        self.assertEqual(
+            context.exception.errors[0]["message"], "Invalid invite token"
+        )
 
     def test_create_store_signing_key(self):
         response = self.client.create_store_signing_key(

--- a/tests/test_publisher_gateway.py
+++ b/tests/test_publisher_gateway.py
@@ -1,3 +1,4 @@
+import json
 from os import getenv
 from unittest.mock import Mock
 
@@ -137,22 +138,23 @@ class PublisherGWTest(VCRTestCase):
         self.assertEqual(response.status_code, 204)
 
     def test_accept_invite_error_raises_error_list(self):
+        body = {
+            "error-list": [
+                {"code": "invalid-token", "message": "Invalid invite token"}
+            ]
+        }
         response = Mock(
             ok=False,
             status_code=400,
-            headers={},
+            headers={"content-type": "application/json"},
             cookies={},
-            text='{"error-list":[{"code":"invalid-token"}]}',
+            text=json.dumps(body),
             url=(
                 "https://api.charmhub.io/v1/charm/test/"
                 "collaborators/invites/accept"
             ),
         )
-        response.json.return_value = {
-            "error-list": [
-                {"code": "invalid-token", "message": "Invalid invite token"}
-            ]
-        }
+        response.json.return_value = body
         response.request.url = response.url
         response.request.headers = {}
         response.request._cookies = {}


### PR DESCRIPTION
## Done
- Improves error messaging coming from the API when accepting an invite to a charm

## QA
- Check out this branch and [this branch on charmhub](https://github.com/canonical/charmhub.io/pull/2360)
- Run charmhub locally with `dotrun serve` pointing to this branch of `store-api` (changing the `requirements.txt` file as well)
- Visit `localhost:8045/accept-invite?package=abbiescharm&token=bad-token`
- Try and accept the invite and see a meaningful error message